### PR TITLE
Issue/009 OIDC ingress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 env:
   PYTHON_VERSION: "3.13"
@@ -85,7 +85,7 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: "temurin"
-          cache: 'gradle'
+          cache: "gradle"
 
       - name: Build and Test Java Adapter
         working-directory: services/ticket-adapter-java

--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,6 @@ audit-report.md
 .codex/
 .cursor/
 .gitignore
+!docs/roadmap/*
+!docs/roadmap/issues/*.*
+!audit/*

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -21,7 +21,9 @@ authors = [{ name = "Siergej Sobolewski", email = "s.sobolewski@hotmail.com" }]
 license = { text = "GPL-2.0-only" }
 requires-python = ">=3.13"
 
-dependencies = []
+dependencies = [
+    "pyjwt[crypto]>=2.8,<3",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/core/src/astradesk_core/utils/oidc.py
+++ b/core/src/astradesk_core/utils/oidc.py
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# File: core/src/astradesk_core/utils/oidc.py
+#
+# OIDC/JWKS access-token verification for AstraDesk ingress (ISSUE 009).
+#
+# Design (contract-first):
+#   INV-OIDC-1  Production startup aborts if OIDC issuer/JWKS/audience config is
+#               absent (fail-closed): build_verifier_from_env() raises.
+#   INV-OIDC-2  Every token is validated for signature (JWKS), iss, aud, exp, and
+#               nbf-if-present before any handler runs.
+#   INV-OIDC-3  The symmetric (HS256) developer path is reachable only when
+#               AUTH_MODE=local-dev AND ENVIRONMENT is not a deployed tier.
+#   INV-OIDC-4  JWKS keys are cached with TTL and re-fetched on a kid miss;
+#               key rotation does not require a restart.
+#
+# This module is transport-agnostic. The FastAPI binding lives in the gateway.
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import jwt
+from jwt import PyJWKClient
+from jwt.exceptions import PyJWKClientError
+
+__all__ = [
+    "AuthConfigError",
+    "AuthError",
+    "LocalDevVerifier",
+    "OIDCSettings",
+    "Principal",
+    "TokenVerifier",
+    "Verifier",
+    "build_verifier_from_env",
+]
+
+# Tiers on which a weakened (symmetric) auth path must never be reachable.
+_DEPLOYED_TIERS = frozenset({"production", "prod", "staging", "stage"})
+
+
+class AuthConfigError(RuntimeError):
+    """Raised at startup when required auth configuration is missing/invalid.
+
+    Surfacing this aborts process start (fail-closed). It must never be caught
+    and downgraded to a permissive default.
+    """
+
+
+class AuthError(Exception):
+    """Raised at request time when a token is absent or fails verification.
+
+    Carries a stable, non-leaking ``code`` suitable for a 401 response. The
+    human-readable message is for logs, not for the client body.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class Principal:
+    """The authenticated caller, derived from verified claims.
+
+    ``roles`` feeds the downstream RBAC choke point (ISSUE 016). Identity is
+    established here; authorization is decided there.
+    """
+
+    subject: str
+    roles: tuple[str, ...]
+    scopes: tuple[str, ...]
+    claims: Mapping[str, Any]
+
+
+class Verifier(Protocol):
+    """Common surface for production and local-dev verifiers."""
+
+    def verify(self, token: str) -> Principal: ...
+
+
+def _split_scope(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return tuple(p for p in value.split() if p)
+    if isinstance(value, Iterable):
+        return tuple(str(p) for p in value if str(p))
+    return ()
+
+
+def _dotted_get(claims: Mapping[str, Any], path: str) -> Any:
+    """Resolve a dotted claim path, e.g. 'realm_access.roles' (Keycloak)."""
+    cur: Any = claims
+    for part in path.split("."):
+        if not isinstance(cur, Mapping) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+@dataclass(frozen=True)
+class OIDCSettings:
+    """Immutable verification settings."""
+
+    issuer: str
+    audience: str
+    jwks_url: str
+    algorithms: tuple[str, ...] = ("RS256",)
+    leeway_seconds: int = 30
+    jwks_cache_ttl: int = 600
+    roles_claim: str = "roles"
+    scope_claim: str = "scope"
+    required_scopes: tuple[str, ...] = ()
+
+    @staticmethod
+    def from_env() -> OIDCSettings:
+        issuer = os.getenv("OIDC_ISSUER", "").strip()
+        audience = os.getenv("OIDC_AUDIENCE", "").strip()
+        jwks_url = os.getenv("OIDC_JWKS_URL", "").strip()
+        missing = [
+            name
+            for name, val in (
+                ("OIDC_ISSUER", issuer),
+                ("OIDC_AUDIENCE", audience),
+                ("OIDC_JWKS_URL", jwks_url),
+            )
+            if not val
+        ]
+        if missing:
+            raise AuthConfigError(
+                "Missing required OIDC configuration: " + ", ".join(missing)
+            )
+        algorithms = tuple(
+            a.strip()
+            for a in os.getenv("OIDC_ALGORITHMS", "RS256").split(",")
+            if a.strip()
+        )
+        required_scopes = tuple(
+            s.strip()
+            for s in os.getenv("OIDC_REQUIRED_SCOPES", "").split(",")
+            if s.strip()
+        )
+        return OIDCSettings(
+            issuer=issuer,
+            audience=audience,
+            jwks_url=jwks_url,
+            algorithms=algorithms or ("RS256",),
+            leeway_seconds=int(os.getenv("OIDC_LEEWAY_SECONDS", "30")),
+            jwks_cache_ttl=int(os.getenv("OIDC_JWKS_CACHE_TTL", "600")),
+            roles_claim=os.getenv("OIDC_ROLES_CLAIM", "roles"),
+            scope_claim=os.getenv("OIDC_SCOPE_CLAIM", "scope"),
+            required_scopes=required_scopes,
+        )
+
+
+class _JwksKeyResolver:
+    """Resolve the verifying key for a token via JWKS, with TTL + kid-miss refresh.
+
+    Wraps PyJWKClient. On a signing-key miss (e.g. just-rotated key), forces one
+    refresh before failing, so rotation does not require a restart (INV-OIDC-4).
+    """
+
+    def __init__(self, jwks_url: str, ttl: int) -> None:
+        self._jwks_url = jwks_url
+        self._ttl = ttl
+        self._lock = threading.Lock()
+        self._client = PyJWKClient(jwks_url, cache_keys=True, lifespan=ttl)
+        self._created = time.monotonic()
+
+    def _rebuild(self) -> None:
+        self._client = PyJWKClient(self._jwks_url, cache_keys=True, lifespan=self._ttl)
+        self._created = time.monotonic()
+
+    def __call__(self, token: str) -> Any:
+        try:
+            return self._client.get_signing_key_from_jwt(token).key
+        except PyJWKClientError as exc:
+            # One forced refresh to honor key rotation without a restart.
+            with self._lock:
+                self._rebuild()
+            try:
+                return self._client.get_signing_key_from_jwt(token).key
+            except PyJWKClientError as exc2:
+                raise AuthError(
+                    "invalid_token", f"no usable signing key: {exc2}"
+                ) from exc
+
+
+class TokenVerifier:
+    """Asymmetric (JWKS) token verifier — the production path.
+
+    The ``key_resolver`` indirection exists for testability: production wires the
+    JWKS resolver; tests inject a deterministic key. Verification semantics are
+    identical regardless of resolver.
+    """
+
+    def __init__(self, settings: OIDCSettings, key_resolver: Any | None = None) -> None:
+        self._s = settings
+        self._resolve_key = key_resolver or _JwksKeyResolver(
+            settings.jwks_url, settings.jwks_cache_ttl
+        )
+
+    def verify(self, token: str) -> Principal:
+        if not token:
+            raise AuthError("missing_token", "no bearer token presented")
+        try:
+            key = self._resolve_key(token)
+        except AuthError:
+            raise
+        except Exception as exc:  # - any resolver failure is fail-closed
+            raise AuthError("invalid_token", f"key resolution failed: {exc}") from exc
+
+        try:
+            claims = jwt.decode(
+                token,
+                key=key,
+                algorithms=list(self._s.algorithms),
+                audience=self._s.audience,
+                issuer=self._s.issuer,
+                leeway=self._s.leeway_seconds,
+                options={
+                    "require": ["exp", "iat"],
+                    "verify_signature": True,
+                    "verify_aud": True,
+                    "verify_iss": True,
+                    "verify_exp": True,
+                    "verify_nbf": True,  # validated only if the claim is present
+                },
+            )
+        except jwt.ExpiredSignatureError as exc:
+            raise AuthError("token_expired", str(exc)) from exc
+        except jwt.InvalidAudienceError as exc:
+            raise AuthError("invalid_audience", str(exc)) from exc
+        except jwt.InvalidIssuerError as exc:
+            raise AuthError("invalid_issuer", str(exc)) from exc
+        except jwt.ImmatureSignatureError as exc:
+            raise AuthError("token_not_yet_valid", str(exc)) from exc
+        except jwt.InvalidTokenError as exc:
+            raise AuthError("invalid_token", str(exc)) from exc
+
+        return self._to_principal(claims)
+
+    def _to_principal(self, claims: Mapping[str, Any]) -> Principal:
+        subject = str(claims.get("sub") or "")
+        if not subject:
+            raise AuthError("invalid_token", "token has no subject")
+        roles_raw = _dotted_get(claims, self._s.roles_claim)
+        roles = (
+            tuple(str(r) for r in roles_raw)
+            if isinstance(roles_raw, list | tuple)
+            else _split_scope(roles_raw)
+        )
+        scopes = _split_scope(claims.get(self._s.scope_claim))
+        if self._s.required_scopes and not set(self._s.required_scopes).issubset(
+            scopes
+        ):
+            raise AuthError("insufficient_scope", "required scope not present")
+        return Principal(
+            subject=subject, roles=roles, scopes=scopes, claims=dict(claims)
+        )
+
+
+class LocalDevVerifier:
+    """Symmetric (HS256) verifier — developer convenience ONLY.
+
+    Constructed solely by build_verifier_from_env() under an explicit local mode
+    that deployed tiers refuse (INV-OIDC-3). Never the default. Identity rigor is
+    identical to production: a subject is required.
+    """
+
+    def __init__(
+        self, secret: str, audience: str, issuer: str, leeway: int = 30
+    ) -> None:
+        if not secret:
+            raise AuthConfigError("local-dev auth requires ASTRADESK_DEV_JWT_SECRET")
+        self._secret = secret
+        self._audience = audience
+        self._issuer = issuer
+        self._leeway = leeway
+
+    def verify(self, token: str) -> Principal:
+        if not token:
+            raise AuthError("missing_token", "no bearer token presented")
+        try:
+            claims = jwt.decode(
+                token,
+                key=self._secret,
+                algorithms=["HS256"],
+                audience=self._audience,
+                issuer=self._issuer,
+                leeway=self._leeway,
+                options={"require": ["exp", "iat"], "verify_signature": True},
+            )
+        except jwt.InvalidTokenError as exc:
+            raise AuthError("invalid_token", str(exc)) from exc
+        subject = str(claims.get("sub") or "")
+        if not subject:
+            raise AuthError("invalid_token", "token has no subject")
+        roles = _split_scope(claims.get("roles"))
+        scopes = _split_scope(claims.get("scope"))
+        return Principal(
+            subject=subject,
+            roles=roles,
+            scopes=scopes,
+            claims=dict(claims),
+        )
+
+
+def build_verifier_from_env() -> Verifier:
+    """Construct the ingress verifier from environment, fail-closed.
+
+    Production (default): requires full OIDC config; returns a JWKS TokenVerifier.
+    local-dev: only when AUTH_MODE=local-dev AND ENVIRONMENT is not a deployed
+    tier; returns a symmetric LocalDevVerifier. Any deployed tier requesting
+    local-dev aborts startup.
+    """
+    auth_mode = os.getenv("AUTH_MODE", "production").strip().lower()
+    environment = os.getenv("ENVIRONMENT", "production").strip().lower()
+
+    if auth_mode == "local-dev":
+        if environment in _DEPLOYED_TIERS:
+            raise AuthConfigError(
+                f"AUTH_MODE=local-dev is forbidden on tier '{environment}'"
+            )
+        return LocalDevVerifier(
+            secret=os.getenv("ASTRADESK_DEV_JWT_SECRET", ""),
+            audience=os.getenv("OIDC_AUDIENCE", "astradesk-local"),
+            issuer=os.getenv("OIDC_ISSUER", "astradesk-local"),
+        )
+
+    if auth_mode != "production":
+        raise AuthConfigError(f"unknown AUTH_MODE: {auth_mode!r}")
+
+    return TokenVerifier(OIDCSettings.from_env())

--- a/core/src/astradesk_core/utils/oidc.py
+++ b/core/src/astradesk_core/utils/oidc.py
@@ -1,19 +1,18 @@
 # SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
 # File: core/src/astradesk_core/utils/oidc.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
 #
-# OIDC/JWKS access-token verification for AstraDesk ingress (ISSUE 009).
+# Description: Implements AstraDesk functionality for core/src/astradesk_core/utils/oidc.py.
 #
-# Design (contract-first):
-#   INV-OIDC-1  Production startup aborts if OIDC issuer/JWKS/audience config is
-#               absent (fail-closed): build_verifier_from_env() raises.
-#   INV-OIDC-2  Every token is validated for signature (JWKS), iss, aud, exp, and
-#               nbf-if-present before any handler runs.
-#   INV-OIDC-3  The symmetric (HS256) developer path is reachable only when
-#               AUTH_MODE=local-dev AND ENVIRONMENT is not a deployed tier.
-#   INV-OIDC-4  JWKS keys are cached with TTL and re-fetched on a kid miss;
-#               key rotation does not require a restart.
+# Copyright (c) 2026 Siergej Sobolewski
 #
-# This module is transport-agnostic. The FastAPI binding lives in the gateway.
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
 from __future__ import annotations
 
 import os

--- a/core/src/astradesk_core/utils/oidc.py
+++ b/core/src/astradesk_core/utils/oidc.py
@@ -27,18 +27,18 @@ from jwt import PyJWKClient
 from jwt.exceptions import PyJWKClientError
 
 __all__ = [
-    "AuthConfigError",
-    "AuthError",
-    "LocalDevVerifier",
-    "OIDCSettings",
-    "Principal",
-    "TokenVerifier",
-    "Verifier",
-    "build_verifier_from_env",
+    'AuthConfigError',
+    'AuthError',
+    'LocalDevVerifier',
+    'OIDCSettings',
+    'Principal',
+    'TokenVerifier',
+    'Verifier',
+    'build_verifier_from_env',
 ]
 
 # Tiers on which a weakened (symmetric) auth path must never be reachable.
-_DEPLOYED_TIERS = frozenset({"production", "prod", "staging", "stage"})
+_DEPLOYED_TIERS = frozenset({'production', 'prod', 'staging', 'stage'})
 
 
 class AuthConfigError(RuntimeError):
@@ -95,7 +95,7 @@ def _split_scope(value: Any) -> tuple[str, ...]:
 def _dotted_get(claims: Mapping[str, Any], path: str) -> Any:
     """Resolve a dotted claim path, e.g. 'realm_access.roles' (Keycloak)."""
     cur: Any = claims
-    for part in path.split("."):
+    for part in path.split('.'):
         if not isinstance(cur, Mapping) or part not in cur:
             return None
         cur = cur[part]
@@ -109,50 +109,44 @@ class OIDCSettings:
     issuer: str
     audience: str
     jwks_url: str
-    algorithms: tuple[str, ...] = ("RS256",)
+    algorithms: tuple[str, ...] = ('RS256',)
     leeway_seconds: int = 30
     jwks_cache_ttl: int = 600
-    roles_claim: str = "roles"
-    scope_claim: str = "scope"
+    roles_claim: str = 'roles'
+    scope_claim: str = 'scope'
     required_scopes: tuple[str, ...] = ()
 
     @staticmethod
     def from_env() -> OIDCSettings:
-        issuer = os.getenv("OIDC_ISSUER", "").strip()
-        audience = os.getenv("OIDC_AUDIENCE", "").strip()
-        jwks_url = os.getenv("OIDC_JWKS_URL", "").strip()
+        issuer = os.getenv('OIDC_ISSUER', '').strip()
+        audience = os.getenv('OIDC_AUDIENCE', '').strip()
+        jwks_url = os.getenv('OIDC_JWKS_URL', '').strip()
         missing = [
             name
             for name, val in (
-                ("OIDC_ISSUER", issuer),
-                ("OIDC_AUDIENCE", audience),
-                ("OIDC_JWKS_URL", jwks_url),
+                ('OIDC_ISSUER', issuer),
+                ('OIDC_AUDIENCE', audience),
+                ('OIDC_JWKS_URL', jwks_url),
             )
             if not val
         ]
         if missing:
-            raise AuthConfigError(
-                "Missing required OIDC configuration: " + ", ".join(missing)
-            )
+            raise AuthConfigError('Missing required OIDC configuration: ' + ', '.join(missing))
         algorithms = tuple(
-            a.strip()
-            for a in os.getenv("OIDC_ALGORITHMS", "RS256").split(",")
-            if a.strip()
+            a.strip() for a in os.getenv('OIDC_ALGORITHMS', 'RS256').split(',') if a.strip()
         )
         required_scopes = tuple(
-            s.strip()
-            for s in os.getenv("OIDC_REQUIRED_SCOPES", "").split(",")
-            if s.strip()
+            s.strip() for s in os.getenv('OIDC_REQUIRED_SCOPES', '').split(',') if s.strip()
         )
         return OIDCSettings(
             issuer=issuer,
             audience=audience,
             jwks_url=jwks_url,
-            algorithms=algorithms or ("RS256",),
-            leeway_seconds=int(os.getenv("OIDC_LEEWAY_SECONDS", "30")),
-            jwks_cache_ttl=int(os.getenv("OIDC_JWKS_CACHE_TTL", "600")),
-            roles_claim=os.getenv("OIDC_ROLES_CLAIM", "roles"),
-            scope_claim=os.getenv("OIDC_SCOPE_CLAIM", "scope"),
+            algorithms=algorithms or ('RS256',),
+            leeway_seconds=int(os.getenv('OIDC_LEEWAY_SECONDS', '30')),
+            jwks_cache_ttl=int(os.getenv('OIDC_JWKS_CACHE_TTL', '600')),
+            roles_claim=os.getenv('OIDC_ROLES_CLAIM', 'roles'),
+            scope_claim=os.getenv('OIDC_SCOPE_CLAIM', 'scope'),
             required_scopes=required_scopes,
         )
 
@@ -185,9 +179,7 @@ class _JwksKeyResolver:
             try:
                 return self._client.get_signing_key_from_jwt(token).key
             except PyJWKClientError as exc2:
-                raise AuthError(
-                    "invalid_token", f"no usable signing key: {exc2}"
-                ) from exc
+                raise AuthError('invalid_token', f'no usable signing key: {exc2}') from exc
 
 
 class TokenVerifier:
@@ -206,13 +198,13 @@ class TokenVerifier:
 
     def verify(self, token: str) -> Principal:
         if not token:
-            raise AuthError("missing_token", "no bearer token presented")
+            raise AuthError('missing_token', 'no bearer token presented')
         try:
             key = self._resolve_key(token)
         except AuthError:
             raise
         except Exception as exc:  # - any resolver failure is fail-closed
-            raise AuthError("invalid_token", f"key resolution failed: {exc}") from exc
+            raise AuthError('invalid_token', f'key resolution failed: {exc}') from exc
 
         try:
             claims = jwt.decode(
@@ -223,31 +215,31 @@ class TokenVerifier:
                 issuer=self._s.issuer,
                 leeway=self._s.leeway_seconds,
                 options={
-                    "require": ["exp", "iat"],
-                    "verify_signature": True,
-                    "verify_aud": True,
-                    "verify_iss": True,
-                    "verify_exp": True,
-                    "verify_nbf": True,  # validated only if the claim is present
+                    'require': ['exp', 'iat'],
+                    'verify_signature': True,
+                    'verify_aud': True,
+                    'verify_iss': True,
+                    'verify_exp': True,
+                    'verify_nbf': True,  # validated only if the claim is present
                 },
             )
         except jwt.ExpiredSignatureError as exc:
-            raise AuthError("token_expired", str(exc)) from exc
+            raise AuthError('token_expired', str(exc)) from exc
         except jwt.InvalidAudienceError as exc:
-            raise AuthError("invalid_audience", str(exc)) from exc
+            raise AuthError('invalid_audience', str(exc)) from exc
         except jwt.InvalidIssuerError as exc:
-            raise AuthError("invalid_issuer", str(exc)) from exc
+            raise AuthError('invalid_issuer', str(exc)) from exc
         except jwt.ImmatureSignatureError as exc:
-            raise AuthError("token_not_yet_valid", str(exc)) from exc
+            raise AuthError('token_not_yet_valid', str(exc)) from exc
         except jwt.InvalidTokenError as exc:
-            raise AuthError("invalid_token", str(exc)) from exc
+            raise AuthError('invalid_token', str(exc)) from exc
 
         return self._to_principal(claims)
 
     def _to_principal(self, claims: Mapping[str, Any]) -> Principal:
-        subject = str(claims.get("sub") or "")
+        subject = str(claims.get('sub') or '')
         if not subject:
-            raise AuthError("invalid_token", "token has no subject")
+            raise AuthError('invalid_token', 'token has no subject')
         roles_raw = _dotted_get(claims, self._s.roles_claim)
         roles = (
             tuple(str(r) for r in roles_raw)
@@ -255,13 +247,9 @@ class TokenVerifier:
             else _split_scope(roles_raw)
         )
         scopes = _split_scope(claims.get(self._s.scope_claim))
-        if self._s.required_scopes and not set(self._s.required_scopes).issubset(
-            scopes
-        ):
-            raise AuthError("insufficient_scope", "required scope not present")
-        return Principal(
-            subject=subject, roles=roles, scopes=scopes, claims=dict(claims)
-        )
+        if self._s.required_scopes and not set(self._s.required_scopes).issubset(scopes):
+            raise AuthError('insufficient_scope', 'required scope not present')
+        return Principal(subject=subject, roles=roles, scopes=scopes, claims=dict(claims))
 
 
 class LocalDevVerifier:
@@ -272,11 +260,9 @@ class LocalDevVerifier:
     identical to production: a subject is required.
     """
 
-    def __init__(
-        self, secret: str, audience: str, issuer: str, leeway: int = 30
-    ) -> None:
+    def __init__(self, secret: str, audience: str, issuer: str, leeway: int = 30) -> None:
         if not secret:
-            raise AuthConfigError("local-dev auth requires ASTRADESK_DEV_JWT_SECRET")
+            raise AuthConfigError('local-dev auth requires ASTRADESK_DEV_JWT_SECRET')
         self._secret = secret
         self._audience = audience
         self._issuer = issuer
@@ -284,24 +270,24 @@ class LocalDevVerifier:
 
     def verify(self, token: str) -> Principal:
         if not token:
-            raise AuthError("missing_token", "no bearer token presented")
+            raise AuthError('missing_token', 'no bearer token presented')
         try:
             claims = jwt.decode(
                 token,
                 key=self._secret,
-                algorithms=["HS256"],
+                algorithms=['HS256'],
                 audience=self._audience,
                 issuer=self._issuer,
                 leeway=self._leeway,
-                options={"require": ["exp", "iat"], "verify_signature": True},
+                options={'require': ['exp', 'iat'], 'verify_signature': True},
             )
         except jwt.InvalidTokenError as exc:
-            raise AuthError("invalid_token", str(exc)) from exc
-        subject = str(claims.get("sub") or "")
+            raise AuthError('invalid_token', str(exc)) from exc
+        subject = str(claims.get('sub') or '')
         if not subject:
-            raise AuthError("invalid_token", "token has no subject")
-        roles = _split_scope(claims.get("roles"))
-        scopes = _split_scope(claims.get("scope"))
+            raise AuthError('invalid_token', 'token has no subject')
+        roles = _split_scope(claims.get('roles'))
+        scopes = _split_scope(claims.get('scope'))
         return Principal(
             subject=subject,
             roles=roles,
@@ -318,21 +304,19 @@ def build_verifier_from_env() -> Verifier:
     tier; returns a symmetric LocalDevVerifier. Any deployed tier requesting
     local-dev aborts startup.
     """
-    auth_mode = os.getenv("AUTH_MODE", "production").strip().lower()
-    environment = os.getenv("ENVIRONMENT", "production").strip().lower()
+    auth_mode = os.getenv('AUTH_MODE', 'production').strip().lower()
+    environment = os.getenv('ENVIRONMENT', 'production').strip().lower()
 
-    if auth_mode == "local-dev":
+    if auth_mode == 'local-dev':
         if environment in _DEPLOYED_TIERS:
-            raise AuthConfigError(
-                f"AUTH_MODE=local-dev is forbidden on tier '{environment}'"
-            )
+            raise AuthConfigError(f"AUTH_MODE=local-dev is forbidden on tier '{environment}'")
         return LocalDevVerifier(
-            secret=os.getenv("ASTRADESK_DEV_JWT_SECRET", ""),
-            audience=os.getenv("OIDC_AUDIENCE", "astradesk-local"),
-            issuer=os.getenv("OIDC_ISSUER", "astradesk-local"),
+            secret=os.getenv('ASTRADESK_DEV_JWT_SECRET', ''),
+            audience=os.getenv('OIDC_AUDIENCE', 'astradesk-local'),
+            issuer=os.getenv('OIDC_ISSUER', 'astradesk-local'),
         )
 
-    if auth_mode != "production":
-        raise AuthConfigError(f"unknown AUTH_MODE: {auth_mode!r}")
+    if auth_mode != 'production':
+        raise AuthConfigError(f'unknown AUTH_MODE: {auth_mode!r}')
 
     return TokenVerifier(OIDCSettings.from_env())

--- a/docs/roadmap/engineering_task.md
+++ b/docs/roadmap/engineering_task.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+Project: AstraDesk
+File: docs/roadmap/engineering_task.md
+Website: https://www.astradesk.dev
+Repository: https://github.com/SSobol77/astradesk
+
+Description: Documents AstraDesk architecture, operation, or component behavior.
+
+Copyright (c) 2026 Siergej Sobolewski
+This file is part of AstraDesk.
+
+AstraDesk is licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for the full license text.
+-->
+
 # ENGINEERING TASK — v0.3.1 Commercial Workhorse Hardening (Safety Core)
 
 **Track**: A (gate to first commercial client)

--- a/docs/roadmap/engineering_task.md
+++ b/docs/roadmap/engineering_task.md
@@ -1,0 +1,115 @@
+# ENGINEERING TASK — v0.3.1 Commercial Workhorse Hardening (Safety Core)
+
+**Track**: A (gate to first commercial client)
+**Milestone**: `v0.3.1 — Commercial Workhorse Hardening` (additive; between v0.3.0 and v0.4.0)
+**Source of truth**: `audit-report.md` Rev 2, `roadmap.md` §2 Phase 1–2
+**Design stance**: contract-first, evidence-driven, fail-closed. Every task states invariants, interfaces, failure modes, and the artifact that proves it done.
+
+---
+
+## 0. Engineering philosophy — best patterns, immunized against their childhood diseases
+
+We are not inventing a new agent paradigm. We adopt the proven shape of MCP-first, policy-governed agent runtimes and **deliberately inoculate against the failure modes those systems are known to hit in their first years.** The audit findings are, almost one-to-one, the industry's known teething diseases. We treat that as a gift: the cures are known.
+
+| Proven analog | Childhood disease (observed industry-wide) | AstraDesk audit symptom | Our inoculation (this milestone unless noted) |
+| :--- | :--- | :--- | :--- |
+| LangChain / LangGraph | Leaky abstractions, hidden control flow, untyped tool I/O | Orchestrator + keyword fallback diverge in policy enforcement | Single enforcement point both paths traverse; typed tool contract |
+| AutoGPT-era agents | Unbounded autonomy; no approval; cost/loop runaway | Write tools can fire without role on fallback path (§7) | Deny-by-default side-effect metadata + approval record (ISSUE 016) |
+| Early MCP adopters | Tool-poisoning via descriptions; declared≠actual schema; auth bolted on late | `schema_ref` never enforced at invoke (§10) | Schema-hash negotiation + reject-on-mismatch (ISSUE 016/028 support) |
+| DIY OIDC/JWT | HS256 dev secret reaches prod; no issuer/aud/expiry checks; no rotation | Active ingress uses HS256 fallback while JWKS verifier sits unused (§7) | Wire JWKS, fail-closed on missing prod config (ISSUE 009) |
+| In-process RAG stacks | Embedding coupled to request path → latency, OOM, cold-start | `SentenceTransformer` constructed in Gateway lifespan (§6) | Isolate into worker — **Track B**, reserved here by interface only |
+| Audit/event pipelines | Event loss on crash (non-durable, ack-before-write) | Core NATS sub, buffer drained before sink persist (§6 Critical) | JetStream durable, ack-after-durable-write, DLQ (ISSUE 019) |
+| Helm/K8s first charts | Secrets in values; root containers; wrong probes; floating tags | Creds in compose/values/tfvars; missing `USER`; floating tags (§7,§3) | Secret refs, non-root UID, pinned digests (ISSUE NEW-02 / NEW-01) |
+| PII-naive RAG/LLM | User data leaks into logs/traces/vector store/model | PII middleware is a no-op; raw query in spans (§7 Critical) | Redact-before-emit, egress allow-list (ISSUE NEW-04) |
+| Multi-tenant retrofits | `tenant_id` added late → data bleed, painful migration | Schema has no tenant column (§ issue #27) | Reserve tenant boundary in schema design now — **Track B** |
+
+**The one invariant that explains half the audit**: in agent runtimes, the *fallback / non-LLM path* is where authority controls quietly fail. Every safety control in this milestone must be proven on **both** the LLM-planned and keyword-fallback execution paths. This is the recurring disease; it gets a dedicated cross-cutting test.
+
+---
+
+## 1. Scope of v0.3.1
+
+In: ingress auth, per-tool authorization invariance, PII/egress boundary, durable audit, fail-closed policy, secret removal, reachable-vuln remediation, reproducible build baseline, executable integration gate.
+
+Out (deferred to Track B with rationale): RAG/embedding worker split, SBOM/sign/canary release pipeline, multi-tenancy, Temporal, Ragas. These are direction, not the client-safety gate.
+
+---
+
+## 2. Cross-cutting invariants (apply to every issue below)
+
+- **INV-DUAL-PATH** — No authority control may depend on the LLM planner being chosen. Identical denial behavior on LLM-planned and keyword-fallback paths. Proven by one shared negative test matrix.
+- **INV-FAIL-CLOSED** — Absence or failure of an authority dependency (OIDC config, OPA endpoint, schema hash) results in denial/startup-abort, never silent allow.
+- **INV-NO-RAW-EGRESS** — No raw user input reaches a log, span attribute, external model, or external tool before classification/redaction.
+- **INV-EVIDENCE** — Each task is "done" only when it emits a reproducible evidence artifact (test run, scan report, render output), not when code merely exists.
+- **INV-LOCAL-MODE-EXPLICIT** — Any developer convenience that weakens a control (symmetric token, seeded secret) is reachable only behind an explicit, named, non-default local mode that production startup refuses.
+
+---
+
+## 3. Dependency order (build sequence)
+
+```
+Phase 0 (done elsewhere): main green + develop gated
+        │
+        ▼
+ISSUE 009 (OIDC ingress) ──► identity is trustworthy
+        │
+        ▼
+ISSUE 016 (RBAC invariant) ──► authority is trustworthy   ◄── ISSUE 028 (fail-closed OPA) reinforces
+        │
+        ▼
+ISSUE NEW-04 (PII/egress) ──► data handling is trustworthy
+        │
+        ▼
+ISSUE 019 (durable audit) ──► evidence is trustworthy
+        │
+        ▼
+ISSUE NEW-01 (supply chain) + NEW-02 (reproducible build) ──► deployment is trustworthy
+        │
+        ▼
+Integration gate executable (roadmap Phase 2.5) ──► all of the above provable in CI
+        │
+        ▼
+✅ Workhorse v1 Gate (roadmap §2)
+```
+
+Rationale for order: you cannot authorize (016) before you can authenticate (009); you cannot prove anything in CI without a reproducible build (NEW-02); audit durability (019) must precede client work because lost audit evidence is unrecoverable.
+
+---
+
+## 4. Verification strategy
+
+| Layer | Method | Gate |
+| :--- | :--- | :--- |
+| Identity | Negative tests: bad issuer/aud/expiry/sig; missing-prod-config startup abort | Fails closed; HS256 unreachable outside local mode |
+| Authority | Dual-path matrix: each `write`/`execute` tool × {LLM, fallback} × {authorized, unauthorized} | Unauthorized denied on every cell |
+| Data | Representative PII/secret corpus through ingress → assert absent from logs/spans/egress | Zero leak |
+| Evidence | Induced crash + sink outage during audit flush → assert zero event loss after recovery | No loss; DLQ replayable |
+| Supply chain | `pip-audit`/image scan; reachability triage | Zero unaccepted reachable Critical/High |
+| Build | `docker compose config` valid; image build from lock; non-root assertion | All green in CI |
+| Dual-path regression | A single CI test that fails if any side-effect tool is registered without role metadata | Prevents reintroduction |
+
+---
+
+## 5. Issue index (this milestone)
+
+| File | # | Type | Principle | GA-gating |
+| :--- | :--- | :--- | :--- | :--- |
+| `ISSUES_009_oidc_ingress.md` | rescope #9 | RESCOPE | Security | yes |
+| `ISSUES_016_rbac_invariant.md` | rescope #16 | RESCOPE | Security | yes |
+| `ISSUES_NEW-04_pii_egress_boundary.md` | NEW-4 | NEW | Security | yes |
+| `ISSUES_019_durable_audit.md` | rescope #19 | RESCOPE | Security | yes |
+| `ISSUES_028_opa_fail_closed.md` | rescope #28 | RESCOPE | Security | yes |
+| `ISSUES_NEW-01_supply_chain.md` | NEW-1 | NEW | Security | yes |
+| `ISSUES_NEW-02_reproducible_build.md` | NEW-2 | NEW | Simplicity | yes |
+
+Each issue file is self-contained and follows one contract template (problem → analog disease → invariants → interface → failure modes → acceptance → evidence → out-of-scope).
+
+---
+
+## 6. Tracker actions (additive; human-executed)
+
+1. Create milestone `v0.3.1 — Commercial Workhorse Hardening`.
+2. Create issues NEW-01, NEW-02, NEW-04 under `v0.3.1`.
+3. Comment+relabel (do not reopen) #9, #16, #19, #28 with the rescoped contract from their issue files; assign to `v0.3.1`.
+4. Leave #18, #21 in `v0.3.0`; they feed the same gate.
+5. No close/reopen of historical milestones. This milestone is purely additive.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+Project: AstraDesk
+File: docs/roadmap/index.md
+Website: https://www.astradesk.dev
+Repository: https://github.com/SSobol77/astradesk
+
+Description: Documents AstraDesk architecture, operation, or component behavior.
+
+Copyright (c) 2026 Siergej Sobolewski
+This file is part of AstraDesk.
+
+AstraDesk is licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for the full license text.
+-->
+
 # AstraDesk Roadmap — From Audit to Commercial Workhorse
 
 **Status date**: 2026-06-28

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -1,0 +1,142 @@
+# AstraDesk Roadmap — From Audit to Commercial Workhorse
+
+**Status date**: 2026-06-28
+**Inputs**: `audit-report.md` Rev 2 (tree `2d59d75`), live tracker (28 issues / 7 milestones)
+**Source of truth**: every roadmap item traces to an audit finding or a tracked issue. No aspirational item is included without evidence. Effort is expressed as relative horizons and **evidence-backed gates**, not invented dates.
+
+---
+
+## 0. How to read this roadmap
+
+AstraDesk is being driven to one near-term outcome: **a dependable "workhorse" framework a developer can deploy to serve a commercial client — safely, simply, and from trustworthy docs.** Enterprise-GA polish (SBOM, signing, canary evaluation, multi-tenancy) is real and planned, but it is **the forward direction, not the entry gate.**
+
+The roadmap therefore has two tracks:
+
+- **Track A — Commercial Workhorse v1**: the minimum that makes AstraDesk safe and reproducible enough to run a real client. This is the priority. It ends at a named, testable gate.
+- **Track B — Enterprise Direction**: the credible evolution beyond Workhorse v1, sequenced for the partner. Real work, later.
+
+Both tracks are mapped onto the **existing milestone taxonomy** (`v0.3.0`–`v0.6.0`) plus **one additive milestone** (`v0.3.1`). Nothing closed is reopened; history is preserved.
+
+---
+
+## 1. The Workhorse Contract (acceptance principles)
+
+These four principles are the definition of "good." Every Track A item exists to satisfy one of them. They are **acceptance bars, not slogans**.
+
+| Principle | What it means concretely | Done when |
+| :--- | :--- | :--- |
+| **Security (good-sense)** | It will not harm a client: real auth at ingress, no secrets in the repo, write/execute tools cannot fire without authorization on **any** code path, PII does not leak into logs/traces/models, audit evidence is not lost on crash. | Negative tests prove each control holds, including the keyword-fallback path. |
+| **Simplicity / easy implementation** | A developer at a client firm stands the stack up from tracked sources in minutes, on one documented baseline. | `docker compose config` is valid, all images build from `uv.lock`/`pyproject.toml`, every `make` target in the docs exists and runs. |
+| **Trustworthy documentation** | Docs describe what the code does, not what was once planned. API routes, ports, commands, and contracts match reality. | Doc snippets and routes are conformance-tested in CI; no claim outranks evidence. |
+| **Zero empty / misleading artifacts** | No `.gitkeep` standing in for a feature, no no-op middleware presented as a control, no design YAML indistinguishable from a deployed one. | Every artifact is either implemented-and-tested or explicitly labelled `DESIGN EXAMPLE — NOT IMPLEMENTED`. |
+
+---
+
+## 2. Track A — Commercial Workhorse v1
+
+### Phase 0 — Stabilize (days; blocks everything, partner-visible)
+
+The single worst look for a partner is a red default branch.
+
+| Item | Evidence | Action |
+| :--- | :--- | :--- |
+| `origin/main` CI is red (Sonar inline-option defect) | audit §5, §11.1; `84a_ci_latest_failed.txt` | Remove the inline shell continuation, pin the scanner image, require one aggregate green status. |
+| CI does not gate `develop` | this cycle's `fix/ci-trigger-develop` | Land the trigger PR (base=`develop`); confirm gates fire on the next feature→develop PR. |
+
+**Exit:** `main` green, `develop` gated. Nothing else proceeds until this holds.
+
+### Phase 1 — Safety Core ("won't hurt a client") → milestone `v0.3.1` (new)
+
+This is the heart of the workhorse. All items are audit Criticals/Highs.
+
+1. **Secrets out of the tree.** Remove credential-bearing defaults from Compose/Helm/Terraform, rotate any reused values, add secret-scanning pre-commit + CI gate. *(§7, H9; NEW-1 partial)*
+2. **Real ingress auth.** Wire the existing JWKS/OIDC verifier into the active Gateway; disable the HS256 dev-secret fallback outside an explicit local mode; validate issuer/audience/expiry. *(§7, issue #9 → RESCOPE)*
+3. **RBAC invariant on side effects.** Declare `side_effect` + `allowed_roles` in registry metadata; deny-by-default; ensure `write`/`execute` tools are gated on **both** the LLM-planned and keyword-fallback paths. *(§7, issue #16 → RESCOPE)*
+4. **PII boundary.** Replace the no-op PII middleware; redact before span attributes/logs; egress allow-list; test with representative PII/secrets. *(§7, NEW-4)*
+5. **Policy fail-closed (minimum viable OPA).** Guarantee no side-effect tool bypasses policy even before a full OPA workload exists; deploy fail-closed OPA + versioned bundle as the completion of this item. *(§7, issue #28 → RESCOPE)*
+6. **Durable audit.** Move the auditor to a JetStream durable consumer with ack-after-durable-write, retry/DLQ, idempotency; crash-recovery test. A workhorse must not lose audit evidence. *(§6 Critical, issue #19 → RESCOPE)*
+7. **Dependency triage (reachable only).** Classify the 102 advisory records by runtime-image presence and reachability; remediate reachable Critical/High; archive a zero-unaccepted evidence file. *(§7, NEW-1)*
+
+**Why here, not later:** these are the controls that decide whether the framework can touch a real client's data and systems without causing harm. They are the literal meaning of "secure workhorse."
+
+### Phase 2 — Deployability & Reproducibility ("easy to stand up") → `v0.3.0` + `v0.3.1`
+
+1. **Valid full Compose.** Fix the `mcp → kb-service` profiled-out dependency so `docker compose config` validates. *(§3.1; NEW-2)*
+2. **Reproducible images.** Rebuild all Python images from `pyproject.toml`/`uv.lock` on **Python 3.13**, non-root `USER`, drop the missing-`requirements.txt` copies. *(§3.1, §3.3, §7; NEW-2)*
+3. **One baseline, pinned.** Align dev/prod DB+cache (pgvector image for dev), pin patches/digests; verify the pgvector migration on an empty volume. *(§6)*
+4. **Deployment verified, not UNVERIFIED.** Run `helm lint`/template/install, `terraform validate`/plan, `istioctl analyze` + a negative-connectivity test — in an audit/CI environment that actually has those tools. *(issues #5/#12/#15/#17 → RESCOPE; audit gap: tooling absent in last run)*
+5. **Executable integration gate.** Repair `tests/integration_tests.py` collection, mark every test, run Compose-backed `pytest -m integration` as a protected gate. *(§3.2, issue #18 → RESCOPE)*
+
+### Phase 3 — Trustworthy Docs & Honest Artifacts ("developer can rely on it") → `v0.4.0`
+
+1. **Kill doc drift.** Reconcile Gateway route (`/v1/run` vs documented `/v1/agents/run`), README ports (8000/8080), and the Make-target mismatch; generate command refs from `make help`. *(§4, §3.1)*
+2. **`make test` == CI.** Make the documented completion command run the same protected checks (not 11 tests / 22%). *(issue #14 → RESCOPE)*
+3. **API contract conformance.** Structural OpenAPI diff gate; fix the 2 extra ops + 42 path-template differences in the Admin runtime. *(§10, NEW-3)*
+4. **Label or implement every example.** Mark non-existent design YAMLs `DESIGN EXAMPLE — NOT IMPLEMENTED`; link real paths for implemented controls. *(§4)*
+5. **Portal E2E for real.** Playwright + mock IdP covering login→agent-query, not mock data. *(issue #23 → implement)*
+6. **The Workhorse Implementation Guide.** A new developer doc: "stand up AstraDesk for a client in N documented steps" — the deliverable that makes it a workhorse for integrators. *(direction of §9 doc-quality findings)*
+
+### ✅ GATE — Commercial Workhorse v1 (definition of "can start client work")
+
+AstraDesk is client-deployable when **all** of the following produce reproducible evidence:
+
+- [ ] `main` and `develop` CI green; integration gate executable and passing.
+- [ ] No secret in any tracked file; secret-scan gate active.
+- [ ] OIDC enforced at active ingress; HS256 fallback disabled outside local mode.
+- [ ] Every `write`/`execute` tool denies without role on **both** planning paths (negative tests prove it).
+- [ ] PII redacted before logs/traces/egress (tested).
+- [ ] Audit durable across an induced crash (recovery test passes).
+- [ ] `docker compose config` valid; all images build from lockfiles on Python 3.13; non-root.
+- [ ] Helm/Terraform/Istio validated (no UNVERIFIED on deployment).
+- [ ] Reachable Critical/High dependency advisories remediated or formally accepted with expiry.
+- [ ] API routes/contracts and `make` targets match docs (conformance-tested).
+- [ ] No empty/misleading artifact remains unlabelled.
+- [ ] Workhorse Implementation Guide published and followed end-to-end by someone who did not write it.
+
+This gate is **below** enterprise GA and **above** "pilot with side effects disabled." It is the bar at which a developer can responsibly run a commercial client.
+
+---
+
+## 3. Track B — Enterprise Direction (for the partner; real, sequenced)
+
+Shown as direction, not entry requirement. Each maps to existing milestones, re-themed honestly.
+
+### B.1 Release-grade supply chain & pipeline → `v0.4.0`/`v0.5.0`
+Complete PIPLINE stages 6–12: multi-arch build, SBOM (`syft`), scan (`grype`/`trivy`), `cosign` sign+verify, GHCR push by immutable digest, environment promotion, canary online-evaluation gates. *(§5; NEW-1 full)*
+
+### B.2 Runtime isolation & SLO qualification → `v0.5.0`
+Split RAG/embedding out of the API Gateway into a separately scaled worker with a bounded RPC contract; remove duplicate inference; add k6/Locust load + fault-injection with p95/tool-success assertions. *(§6, NEW-5)*
+
+### B.3 Enterprise features → `v0.5.0`/`v0.6.0`
+Multi-tenancy (per-tenant memory/data; schema `tenant_id`) *(issue #27)*; Temporal durable workflows *(issue #25)*; RAG evaluation with Ragas *(issue #26)*; advanced OPA RBAC beyond the Phase-1 fail-closed minimum *(issue #28)*.
+
+### B.4 Operational resilience → `v0.6.0`
+Executed Postgres/RAG/audit backup-restore drills with measured RPO/RTO and incident authority; Prometheus alert rules + Alertmanager with proven notification delivery. *(NEW-6; issue #24)*
+
+---
+
+## 4. What we will NOT promise yet (anti-fantasy)
+
+To keep the partner conversation credible:
+
+- **No certification claims.** `docs/en/08_security_governance.md` is a conceptual mapping, not an assessment. SOC2/ISO statements are out of scope until evidenced.
+- **No "enterprise-ready" label on Workhorse v1.** It is commercial-client-capable under defined controls, not a multi-tenant SaaS-grade platform.
+- **No invented dates beyond tracked milestones.** Horizons are gates with evidence; calendar dates inherit from the tracker (`v0.3.0` 2026-07-18 …) and move only with re-baseline, not optimism.
+- **No GA until Track A gate + B.1 supply-chain + B.2 isolation are evidenced.**
+
+---
+
+## 5. Tracker actions (additive only — no history broken)
+
+1. **Add milestone `v0.3.1 — Commercial Workhorse Hardening`** between `v0.3.0` and `v0.4.0`. This is the Track A safety/deployability gate. Purely additive; touches no closed milestone.
+2. **Create NEW-1…NEW-6** as issues, assigned: NEW-1/NEW-4 → `v0.3.1`; NEW-2 → `v0.3.1`; NEW-3 → `v0.4.0`; NEW-5 → `v0.5.0`; NEW-6 → `v0.6.0`.
+3. **RESCOPE in place** (comment + relabel, do not reopen): #9, #16, #18, #19, #28 carry residual workhorse debt into `v0.3.0`/`v0.3.1`; #14, #5, #12, #15, #17 carry deployability/verification debt.
+4. **KEEP**: #21 (OIDC portal) and #23 (E2E) move into the Track A scope they belong to; #24/#25/#26/#27 stay in Track B milestones.
+5. All execution (issue/milestone creation, closing, labelling) is performed by a human; this roadmap is the plan, not the mutation.
+
+---
+
+## 6. One-line summary for each audience
+
+- **For the integrator/developer**: AstraDesk reaches a defined, tested "safe to deploy for a client" gate (Track A) before any enterprise-scale feature work.
+- **For the partner**: a credible, evidence-anchored evolution from working framework → release-grade supply chain → isolated, multi-tenant, operationally-qualified platform (Track B), with no claim ahead of proof.

--- a/docs/roadmap/issues/ISSUES_009_oidc_ingress.md
+++ b/docs/roadmap/issues/ISSUES_009_oidc_ingress.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+Project: AstraDesk
+File: docs/roadmap/issues/ISSUES_009_oidc_ingress.md
+Website: https://www.astradesk.dev
+Repository: https://github.com/SSobol77/astradesk
+
+Description: Documents AstraDesk architecture, operation, or component behavior.
+
+Copyright (c) 2026 Siergej Sobolewski
+This file is part of AstraDesk.
+
+AstraDesk is licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for the full license text.
+-->
+
 # ISSUES_009 — Wire JWKS/OIDC at active ingress (RESCOPE of #9)
 
 - **Track / Milestone**: A / `v0.3.1`

--- a/docs/roadmap/issues/ISSUES_009_oidc_ingress.md
+++ b/docs/roadmap/issues/ISSUES_009_oidc_ingress.md
@@ -1,0 +1,48 @@
+# ISSUES_009 — Wire JWKS/OIDC at active ingress (RESCOPE of #9)
+
+- **Track / Milestone**: A / `v0.3.1`
+- **Type**: RESCOPE of closed #9 (retain historical closure; residual control moved here)
+- **Workhorse principle**: Security (good-sense)
+- **GA-gating**: yes — identity must be trustworthy before authority (016)
+- **Audit anchors**: §7 (Critical); `services/api-gateway/src/gateway/main.py:69-105`; `core/src/astradesk_core/utils/auth.py:125-240`
+- **Depends on**: Phase 0 (main green)
+- **Blocks**: ISSUE 016, NEW-04, 019
+
+## Problem (current evidence)
+The active Gateway authenticates with an HS256 development-secret fallback. A tested JWKS/OIDC verifier already exists in `astradesk_core.utils.auth` but is **not** wired into the live ingress. Documentation claims OIDC; the running code does not use it.
+
+## Industry analog & childhood disease
+DIY OIDC/JWT integrations routinely ship a symmetric dev secret that survives into production, skip issuer/audience/expiry validation, and have no key-rotation story. The result is forgeable tokens and silent trust of the wrong issuer. We immunize by making asymmetric JWKS the only production path and refusing to start without it.
+
+## Target contract (invariants)
+- **INV-OIDC-1**: Production startup MUST abort if OIDC issuer/JWKS/audience config is absent or unreachable (INV-FAIL-CLOSED).
+- **INV-OIDC-2**: Every request token is validated for signature (JWKS), `iss`, `aud`, `exp`, `nbf`, and required scope/claim set before any handler runs.
+- **INV-OIDC-3**: The HS256 symmetric path is reachable only behind `ASTRADESK_AUTH_MODE=local-dev` (named, non-default); production refuses that value (INV-LOCAL-MODE-EXPLICIT).
+- **INV-OIDC-4**: JWKS keys are cached with TTL and re-fetched on `kid` miss; rotation does not require a restart.
+
+## Interface / design
+- Single auth dependency injected at the Gateway ingress boundary; remove inline secret handling from `gateway/main.py`.
+- Config surface: `OIDC_ISSUER`, `OIDC_AUDIENCE`, `OIDC_JWKS_URL` (or discovery), `AUTH_MODE`.
+- Verifier reused from `astradesk_core.utils.auth` (no second implementation).
+
+## Failure modes & required behavior
+| Failure | Required behavior |
+| :--- | :--- |
+| Missing prod OIDC config | Startup aborts with explicit error; no fallback to HS256 |
+| JWKS endpoint unreachable at request time | 503 with cached keys if valid; deny if no usable key |
+| Expired / wrong `aud` / wrong `iss` token | 401, audited, no handler execution |
+| Unknown `kid` | One JWKS refresh, then deny if still unknown |
+| `AUTH_MODE=local-dev` set in production image | Startup refuses |
+
+## Acceptance criteria (Definition of Done)
+- [ ] Live ingress validates via JWKS; HS256 removed from default path.
+- [ ] Negative tests: bad signature, wrong `iss`, wrong `aud`, expired, `nbf` in future, unknown `kid` → all denied and audited.
+- [ ] Startup-abort test for missing prod config.
+- [ ] Rotation test: new signing key honored without restart.
+- [ ] `local-dev` refused by a production-profiled startup.
+
+## Verification evidence (artifact)
+`audit/evidence/` (next run): auth negative-matrix test output + startup-abort test log.
+
+## Out of scope
+Portal front-channel OIDC (#21), token exchange for downstream services (Track B).

--- a/docs/roadmap/issues/ISSUES_016_rbac_invariant.md
+++ b/docs/roadmap/issues/ISSUES_016_rbac_invariant.md
@@ -1,0 +1,48 @@
+# ISSUES_016 — RBAC invariant on every side-effect path (RESCOPE of #16)
+
+- **Track / Milestone**: A / `v0.3.1`
+- **Type**: RESCOPE of closed #16
+- **Workhorse principle**: Security (good-sense)
+- **GA-gating**: yes — the single highest-impact control for client safety
+- **Audit anchors**: §7 (Critical); `services/api-gateway/src/gateway/main.py:143-154`; `services/api-gateway/src/tools/ops_actions.py:77-119`; `services/api-gateway/src/tools/tickets_proxy.py:157-181`; `services/api-gateway/src/agents/base.py:279`
+- **Depends on**: ISSUE 009 (identity)
+- **Reinforced by**: ISSUE 028 (fail-closed OPA)
+
+## Problem (current evidence)
+RBAC is not invariant. The registry supports `allowed_roles`, but built-in tools are registered without roles. `restart_service` does a direct role check; `create_ticket` depends on an optional OPA client that the **keyword-fallback** registry execution never passes. A `write` tool can therefore execute without the documented per-tool role policy when the planner is bypassed.
+
+## Industry analog & childhood disease
+AutoGPT-era agents executed side effects with no authorization gate; later frameworks added RBAC on the "happy" LLM path but left tool-execution shortcuts (retries, keyword routing, direct registry calls) ungated. The disease is **authority that depends on which code path was taken.** We immunize by making authorization a property of the tool invocation itself, not of the planner.
+
+## Target contract (invariants)
+- **INV-RBAC-1 (INV-DUAL-PATH)**: Authorization is enforced at one choke point that **both** the LLM-planned and keyword-fallback paths must traverse. No tool executes outside it.
+- **INV-RBAC-2**: Every tool declares `side_effect ∈ {read, write, execute}` and `allowed_roles` in registry metadata at registration; registration of a side-effect tool without roles fails fast.
+- **INV-RBAC-3 (INV-FAIL-CLOSED)**: Unknown tool, missing metadata, or unavailable policy → deny.
+- **INV-RBAC-4**: `write`/`execute` require an approval/change record id; absence → deny + audit.
+
+## Interface / design
+- Move authorization into the registry/orchestrator boundary so fallback execution cannot skip it; `agents/base.py` fallback calls the same gated invoke.
+- Tool metadata schema extended: `{name, side_effect, allowed_roles, requires_approval}`.
+- A startup invariant check enumerates registered tools and aborts if any `side_effect != read` lacks `allowed_roles`.
+
+## Failure modes & required behavior
+| Failure | Required behavior |
+| :--- | :--- |
+| Side-effect tool registered without roles | Startup aborts (catch at boot, not at call) |
+| Unauthorized role invokes `write`/`execute` (LLM path) | Deny + audit |
+| Same invocation via keyword-fallback | Identical deny + audit |
+| `write` without approval record | Deny + audit |
+| Policy backend unavailable | Deny (fail-closed), not allow |
+
+## Acceptance criteria (Definition of Done)
+- [ ] All built-in tools carry `side_effect` + `allowed_roles`.
+- [ ] **Dual-path negative matrix**: for each `write`/`execute` tool × {LLM, fallback} × {authorized, unauthorized}, unauthorized is denied in every cell.
+- [ ] Boot-time invariant test: registering a roleless side-effect tool aborts startup.
+- [ ] Approval-record enforcement test for `write`/`execute`.
+- [ ] CI regression test that fails if any side-effect tool lacks role metadata.
+
+## Verification evidence (artifact)
+Dual-path RBAC matrix test output; boot-invariant test log.
+
+## Out of scope
+Policy authoring/bundle distribution (ISSUE 028); fine-grained ABAC (Track B).

--- a/docs/roadmap/issues/ISSUES_016_rbac_invariant.md
+++ b/docs/roadmap/issues/ISSUES_016_rbac_invariant.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+Project: AstraDesk
+File: docs/roadmap/issues/ISSUES_016_rbac_invariant.md
+Website: https://www.astradesk.dev
+Repository: https://github.com/SSobol77/astradesk
+
+Description: Documents AstraDesk architecture, operation, or component behavior.
+
+Copyright (c) 2026 Siergej Sobolewski
+This file is part of AstraDesk.
+
+AstraDesk is licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for the full license text.
+-->
+
 # ISSUES_016 — RBAC invariant on every side-effect path (RESCOPE of #16)
 
 - **Track / Milestone**: A / `v0.3.1`

--- a/docs/roadmap/issues/ISSUES_019_durable_audit.md
+++ b/docs/roadmap/issues/ISSUES_019_durable_audit.md
@@ -1,0 +1,47 @@
+# ISSUES_019 — Durable, recoverable audit (RESCOPE of #19)
+
+- **Track / Milestone**: A / `v0.3.1`
+- **Type**: RESCOPE of closed #19 (corrects the prior stale "stub" claim — subscriber is real)
+- **Workhorse principle**: Security (good-sense) — non-repudiation
+- **GA-gating**: yes — lost audit evidence is unrecoverable; a client-facing workhorse cannot lose it
+- **Audit anchors**: §6 (Critical); `services/auditor/main.py:261-283`, `338-377`
+- **Depends on**: none (parallelizable), but precedes client work
+
+## Problem (current evidence)
+The auditor is a genuine NATS subscriber (386 LOC), not a stub. However it uses a **non-durable core NATS subscription**, drains its in-memory buffer **before** sink persistence, and suppresses sink exceptions. A process or sink failure can lose audit events despite the module's "reliable persistence" claim.
+
+## Industry analog & childhood disease
+Event/audit pipelines commonly ack-before-write and buffer in memory for throughput, then lose data on the first crash or sink outage — discovered only during an incident when the audit trail has a hole. The disease is **throughput optimization that sacrifices the durability the component exists to provide.** We immunize with durable consumers and ack-after-durable-write.
+
+## Target contract (invariants)
+- **INV-AUD-1**: An event is acknowledged to the broker only **after** it is durably persisted to a sink (ack-after-write).
+- **INV-AUD-2**: The subscription is a JetStream **durable** consumer; restart resumes from the last unacked message.
+- **INV-AUD-3**: Sink failure triggers bounded retry, then routes to a DLQ; events are never silently dropped.
+- **INV-AUD-4**: Writes are idempotent (idempotency key) so redelivery does not duplicate audit records.
+- **INV-AUD-5**: Audit availability is independent of the request path — Gateway does not block on audit, but audit cannot lose what it accepted.
+
+## Interface / design
+- Migrate subscription to JetStream durable consumer with explicit ack.
+- Persist → ack ordering; remove pre-write buffer drain.
+- DLQ subject + replay tool; idempotency key derived from event id.
+
+## Failure modes & required behavior
+| Failure | Required behavior |
+| :--- | :--- |
+| Process crash mid-flush | On restart, unacked events redelivered; zero loss |
+| Elasticsearch/S3 sink outage | Retry with backoff, then DLQ; no ack until durable |
+| Duplicate redelivery | Idempotent write; single audit record |
+| Sink throws | Surfaced + retried, not suppressed |
+
+## Acceptance criteria (Definition of Done)
+- [ ] Durable JetStream consumer; ack-after-durable-write.
+- [ ] Crash-recovery test: kill during flush → zero event loss after restart.
+- [ ] Sink-outage test: induced outage → events land in DLQ, replay restores them.
+- [ ] Idempotency test: forced redelivery → no duplicates.
+- [ ] Removed exception suppression; failures observable in metrics.
+
+## Verification evidence (artifact)
+Crash-recovery and sink-outage test logs; DLQ replay output.
+
+## Out of scope
+WORM/object-lock retention tier and long-term archival policy (Track B / ops).

--- a/docs/roadmap/issues/ISSUES_019_durable_audit.md
+++ b/docs/roadmap/issues/ISSUES_019_durable_audit.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+Project: AstraDesk
+File: docs/roadmap/issues/ISSUES_019_durable_audit.md
+Website: https://www.astradesk.dev
+Repository: https://github.com/SSobol77/astradesk
+
+Description: Documents AstraDesk architecture, operation, or component behavior.
+
+Copyright (c) 2026 Siergej Sobolewski
+This file is part of AstraDesk.
+
+AstraDesk is licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for the full license text.
+-->
+
 # ISSUES_019 — Durable, recoverable audit (RESCOPE of #19)
 
 - **Track / Milestone**: A / `v0.3.1`

--- a/docs/roadmap/issues/ISSUES_028_opa_fail_closed.md
+++ b/docs/roadmap/issues/ISSUES_028_opa_fail_closed.md
@@ -1,0 +1,47 @@
+# ISSUES_028 — Deployable fail-closed OPA + schema-hash pinning (RESCOPE of #28)
+
+- **Track / Milestone**: A / `v0.3.1`
+- **Type**: RESCOPE of open #28 (narrow to deployable, uniform enforcement)
+- **Workhorse principle**: Security (good-sense)
+- **GA-gating**: yes — policy must be a real, uniform boundary, not optional code
+- **Audit anchors**: §7; §10; `services/api-gateway/src/gateway/orchestrator.py:173-179`; `mcp/src/gateway/config.py:41-47`; `mcp/src/gateway/gateway.py:87-180`
+- **Depends on**: ISSUE 016 (RBAC choke point exists to attach policy to)
+
+## Problem (current evidence)
+The orchestrator calls OPA before LLM-planned tools, but: no OPA server/sidecar/bundle is tracked, fallback calls are not centrally policy-checked, and `schema_ref` is configuration metadata never compared against a caller schema hash at invoke. Policy exists as code, not as a deployable, uniform, fail-closed boundary.
+
+## Industry analog & childhood disease
+Early MCP/tool ecosystems suffered tool-poisoning (a tool's declared schema/description drifts from what it actually accepts) and "optional policy" that is present in code but absent in deployment. The disease is **policy and schema integrity that are advisory rather than enforced.** We immunize with a deployed fail-closed OPA and schema-hash negotiation that rejects mismatches.
+
+## Target contract (invariants)
+- **INV-OPA-1 (INV-FAIL-CLOSED)**: If the OPA endpoint is unavailable or returns no decision, the action is denied.
+- **INV-OPA-2 (INV-DUAL-PATH)**: Both LLM-planned and fallback tool calls pass the same policy check.
+- **INV-OPA-3**: Policy bundles are versioned and their version is recorded in the audit decision.
+- **INV-SCHEMA-1**: Tool invocation carries a `schema_hash`; the gateway canonicalizes and hashes the declared schema and **rejects on mismatch**; both expected and received hashes are audited.
+
+## Interface / design
+- Tracked OPA workload (sidecar/deployment) + bundle directory; health-gated.
+- Policy check moved to the shared invoke choke point from ISSUE 016 (so fallback is covered).
+- `schema_hash` added to the MCP call contract; canonical JSON schema hashing; mismatch → reject.
+
+## Failure modes & required behavior
+| Failure | Required behavior |
+| :--- | :--- |
+| OPA endpoint down | Deny (fail-closed) + audit |
+| Decision absent/ambiguous | Deny |
+| Tool schema hash mismatch | Reject invocation + audit expected/received |
+| Fallback path tool call | Same policy decision as LLM path |
+| Bundle version unknown | Deny until a valid versioned bundle loads |
+
+## Acceptance criteria (Definition of Done)
+- [ ] OPA deployed and health-gated; bundle versioned.
+- [ ] Bypass test: OPA down → side effects denied, not allowed.
+- [ ] Dual-path test: fallback tool call is policy-checked identically.
+- [ ] Schema-hash negotiation enforced; mismatch rejected with audit of both hashes.
+- [ ] Decision + bundle version present in audit records.
+
+## Verification evidence (artifact)
+OPA-down bypass test log; schema-mismatch rejection test; dual-path policy test.
+
+## Out of scope
+Rich policy authoring UX, policy simulation/CI policy tests as a separate suite (Track B).

--- a/docs/roadmap/issues/ISSUES_028_opa_fail_closed.md
+++ b/docs/roadmap/issues/ISSUES_028_opa_fail_closed.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+Project: AstraDesk
+File: docs/roadmap/issues/ISSUES_028_opa_fail_closed.md
+Website: https://www.astradesk.dev
+Repository: https://github.com/SSobol77/astradesk
+
+Description: Documents AstraDesk architecture, operation, or component behavior.
+
+Copyright (c) 2026 Siergej Sobolewski
+This file is part of AstraDesk.
+
+AstraDesk is licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for the full license text.
+-->
+
 # ISSUES_028 — Deployable fail-closed OPA + schema-hash pinning (RESCOPE of #28)
 
 - **Track / Milestone**: A / `v0.3.1`

--- a/docs/roadmap/issues/ISSUES_NEW-01_supply_chain.md
+++ b/docs/roadmap/issues/ISSUES_NEW-01_supply_chain.md
@@ -1,0 +1,45 @@
+# ISSUES_NEW-01 — Dependency & supply-chain remediation (NEW)
+
+- **Track / Milestone**: A / `v0.3.1`
+- **Type**: NEW
+- **Workhorse principle**: Security (good-sense)
+- **GA-gating**: yes for reachable Critical/High; full SBOM/sign pipeline is Track B
+- **Audit anchors**: §3.3, §7; `audit/evidence/19_pip_audit.txt`; `98_ci_stage_map.txt`
+- **Depends on**: NEW-02 (a reproducible image to scan)
+
+## Problem (current evidence)
+`pip-audit` reports 102 known vulnerability records across 23 installed packages; GitHub CI has no dependency/image scan or SBOM gate. The locked environment does not meet the declared "no critical/high vulnerability" criterion.
+
+## Industry analog & childhood disease
+Python/ML stacks accumulate large transitive advisory counts; teams either ignore them or attempt a blind "update everything" that breaks the resolver. The disease is **treating a raw advisory count as either irrelevant or as a blocking wall, instead of triaging by reachability.** We immunize with reachability triage + a scanning gate that tracks accepted risk with expiry.
+
+## Target contract (invariants)
+- **INV-SC-1**: Every advisory is dispositioned: remediated, not-present-in-runtime-image, or accepted-with-expiry + justification.
+- **INV-SC-2**: No **reachable** Critical/High advisory remains unaccepted before the Workhorse v1 gate.
+- **INV-SC-3 (INV-FAIL-CLOSED)**: CI dependency/image scan fails the build on a new unaccepted reachable Critical/High.
+- **INV-SC-4**: Acceptances are time-boxed; an expired acceptance fails CI.
+
+## Interface / design
+- Triage matrix: advisory × present-in-runtime-image? × reachable? → disposition.
+- CI gate: `pip-audit` + image scan (`grype`/`trivy`) with an allow-list file carrying expiry dates and justifications.
+- (Track B handoff: SBOM via `syft`, signing, digest verification.)
+
+## Failure modes & required behavior
+| Failure | Required behavior |
+| :--- | :--- |
+| New reachable Critical/High introduced | CI fails |
+| Advisory only in build stage, not runtime | Documented, not blocking |
+| Acceptance past expiry | CI fails |
+| Resolver conflict on remediation | Pin via tested constraint set, not blind upgrade |
+
+## Acceptance criteria (Definition of Done)
+- [ ] All 102 records dispositioned in a tracked triage file.
+- [ ] Zero unaccepted reachable Critical/High.
+- [ ] CI scan gate active and failing-closed on regression.
+- [ ] Time-boxed acceptances with justification + expiry.
+
+## Verification evidence (artifact)
+Triage file; green scan-gate run; expiry-enforcement test.
+
+## Out of scope
+SBOM generation, cosign signing, digest-verified promotion (Track B B.1).

--- a/docs/roadmap/issues/ISSUES_NEW-01_supply_chain.md
+++ b/docs/roadmap/issues/ISSUES_NEW-01_supply_chain.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+Project: AstraDesk
+File: docs/roadmap/issues/ISSUES_NEW-01_supply_chain.md
+Website: https://www.astradesk.dev
+Repository: https://github.com/SSobol77/astradesk
+
+Description: Documents AstraDesk architecture, operation, or component behavior.
+
+Copyright (c) 2026 Siergej Sobolewski
+This file is part of AstraDesk.
+
+AstraDesk is licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for the full license text.
+-->
+
 # ISSUES_NEW-01 — Dependency & supply-chain remediation (NEW)
 
 - **Track / Milestone**: A / `v0.3.1`

--- a/docs/roadmap/issues/ISSUES_NEW-02_reproducible_build.md
+++ b/docs/roadmap/issues/ISSUES_NEW-02_reproducible_build.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+Project: AstraDesk
+File: docs/roadmap/issues/ISSUES_NEW-02_reproducible_build.md
+Website: https://www.astradesk.dev
+Repository: https://github.com/SSobol77/astradesk
+
+Description: Documents AstraDesk architecture, operation, or component behavior.
+
+Copyright (c) 2026 Siergej Sobolewski
+This file is part of AstraDesk.
+
+AstraDesk is licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for the full license text.
+-->
+
 # ISSUES_NEW-02 — Reproducible containers, valid Compose, one baseline (NEW)
 
 - **Track / Milestone**: A / `v0.3.1`

--- a/docs/roadmap/issues/ISSUES_NEW-02_reproducible_build.md
+++ b/docs/roadmap/issues/ISSUES_NEW-02_reproducible_build.md
@@ -1,0 +1,48 @@
+# ISSUES_NEW-02 — Reproducible containers, valid Compose, one baseline (NEW)
+
+- **Track / Milestone**: A / `v0.3.1`
+- **Type**: NEW
+- **Workhorse principle**: Simplicity / easy implementation
+- **GA-gating**: yes — an integrator must stand the stack up from tracked sources
+- **Audit anchors**: §3.1, §3.3, §6, §7; `audit/evidence/40_compose.txt`; `95_hypothesis_checks.txt`; `73_source_path_checks.txt`
+- **Depends on**: none; **blocks** NEW-01 (need a reproducible image to scan) and the integration gate
+
+## Problem (current evidence)
+Full Compose validation fails (`mcp` depends on profiled-out `kb-service`). Dev API/domain Dockerfiles use Python 3.11, use `pip`, and copy non-existent `requirements.txt`. Package metadata is uniformly 3.13 but five images are 3.11. Several runtime Dockerfiles have no final `USER`. Dev/prod DB+cache baselines diverge with floating tags.
+
+## Industry analog & childhood disease
+First-generation Helm/Compose/K8s setups ship root containers, floating `:latest`/`:8-alpine` tags, secrets in values, and Dockerfiles that drift from the real dependency manifest. The disease is **"works on my machine" packaging** — non-reproducible images that an integrator cannot rebuild. We immunize by building only from `pyproject.toml`/`uv.lock`, pinning by digest, and running non-root.
+
+## Target contract (invariants)
+- **INV-BUILD-1**: Every Python image builds solely from `pyproject.toml` + `uv.lock` (no `pip`, no `requirements.txt`).
+- **INV-BUILD-2**: One Python baseline — **3.13 latest patch** — across all images and CI.
+- **INV-BUILD-3**: Every runtime image declares a fixed numeric **non-root** `USER`; read-only root FS where feasible.
+- **INV-BUILD-4**: `docker compose -f docker-compose.yml config` and the dev variant both validate.
+- **INV-BUILD-5**: Base images, DB, and cache are pinned by digest; dev and prod share the same engine baseline (pgvector image for dev).
+
+## Interface / design
+- Multi-stage uv-based Dockerfile pattern (builder installs from lock; runtime is slim, non-root).
+- Fix the Compose profile dependency (`mcp`/`kb-service`) so the graph is valid.
+- Pin `postgres`/`pgvector`/`redis` by digest; verify the pgvector migration on an empty volume.
+
+## Failure modes & required behavior
+| Failure | Required behavior |
+| :--- | :--- |
+| `compose config` invalid | CI fails; fix profile/dependency semantics |
+| Image built with `pip`/missing requirements | Build fails; only lock-based path allowed |
+| Root container | Image lint fails (non-root assertion) |
+| Floating tag | CI rejects unpinned base/DB/cache references |
+| pgvector migration on selected dev image fails | Use pinned pgvector image; verified on empty volume |
+
+## Acceptance criteria (Definition of Done)
+- [ ] Both Compose files validate in CI.
+- [ ] All Python images build from `uv.lock` on Python 3.13, non-root.
+- [ ] Base/DB/cache pinned by digest; dev/prod baselines aligned.
+- [ ] pgvector migration verified on a clean volume in CI.
+- [ ] Non-root assertion test across tracked Dockerfiles.
+
+## Verification evidence (artifact)
+`docker compose config` pass logs; image build + non-root assertion; clean-volume migration run.
+
+## Out of scope
+Multi-arch build/push, SBOM/sign (Track B B.1); secret-reference wiring is shared with NEW-01/§7 secret removal.

--- a/docs/roadmap/issues/ISSUES_NEW-03_contract_conformance.md
+++ b/docs/roadmap/issues/ISSUES_NEW-03_contract_conformance.md
@@ -1,0 +1,45 @@
+# ISSUES_NEW-03 — API implementation-contract conformance (NEW)
+
+- **Track / Milestone**: A / `v0.4.0`
+- **Type**: NEW
+- **Workhorse principle**: Trustworthy documentation
+- **GA-gating**: yes — an integrator's generated client must match the running service
+- **Audit anchors**: §4; §10; `docs/api.md:102-205`; `services/api-gateway/src/gateway/main.py:275-286`; `audit/evidence/72_admin_contract_diff.txt`; `services/admin-portal/scripts/check-openapi-sync.ts:53-70`
+- **Depends on**: ISSUE 009 (auth shape affects documented operations), NEW-02 (reproducible env to regenerate in)
+
+## Problem (current evidence)
+Two contract truths diverge from implementation. (1) The public Gateway doc specifies `/v1/agents/run`; the active code exposes `/v1/run`. (2) The runtime Admin API exposes 76 operations vs 74 canonical; after parameter-name normalization it has two undocumented operations, and exact path templates differ for 42 canonical operations. The portal's generated-client check compares **file mtimes**, not regenerated content, so a touched file passes without matching the spec.
+
+## Industry analog & childhood disease
+OpenAPI-first projects routinely let the spec become aspirational: the document and the generated SDK drift from the handlers, and "sync" checks verify timestamps instead of content. Integrators then build against a contract the server does not honor. The disease is **a contract that is asserted, not enforced.** We immunize by generating the runtime schema in CI and structurally diffing it against the source of truth, and by regenerating clients to a temp dir and requiring a zero diff.
+
+## Target contract (invariants)
+- **INV-API-1**: One public Gateway route is canonical; docs, spec, tests, and code agree on it.
+- **INV-API-2**: The runtime Admin schema is **structurally identical** to canonical `1.2.0`: same operation set, parameter names, path templates, request/response schemas, and status codes.
+- **INV-API-3 (INV-FAIL-CLOSED)**: A structural diff between runtime schema and canonical spec fails CI (treated as a breaking-contract event).
+- **INV-API-4**: Generated portal client is verified by regenerate-to-temp + zero-diff, never by mtime.
+
+## Interface / design
+- CI step emits the runtime OpenAPI from the live app and diffs it (operations/params/schemas/status) against `openapi/astradesk-admin.v1.yaml`.
+- Route-conformance test asserts the implemented Gateway path equals the documented one.
+- Replace `check-openapi-sync.ts` mtime logic with deterministic regeneration into a scratch dir + `diff`.
+
+## Failure modes & required behavior
+| Failure | Required behavior |
+| :--- | :--- |
+| Runtime schema adds/removes an operation vs canonical | CI fails (breaking contract) |
+| Path-template / param-name drift | CI fails with the specific diff |
+| Gateway route ≠ documented route | Route-conformance test fails |
+| Generated client touched but content-stale | Regenerate-diff fails |
+
+## Acceptance criteria (Definition of Done)
+- [ ] Canonical Gateway route chosen; docs/spec/tests/code aligned; route-conformance test passes.
+- [ ] Runtime-vs-canonical structural diff is clean (2 extra ops + 42 path-template diffs resolved).
+- [ ] CI structural-diff gate active and failing-closed on drift.
+- [ ] Portal client check is regenerate-to-temp + zero-diff.
+
+## Verification evidence (artifact)
+Clean structural-diff report; route-conformance test log; regenerate-diff CI output.
+
+## Out of scope
+Spec redesign / new endpoints; API versioning beyond the existing `1.2.0` contract axis.

--- a/docs/roadmap/issues/ISSUES_NEW-03_contract_conformance.md
+++ b/docs/roadmap/issues/ISSUES_NEW-03_contract_conformance.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+Project: AstraDesk
+File: docs/roadmap/issues/ISSUES_NEW-03_contract_conformance.md
+Website: https://www.astradesk.dev
+Repository: https://github.com/SSobol77/astradesk
+
+Description: Documents AstraDesk architecture, operation, or component behavior.
+
+Copyright (c) 2026 Siergej Sobolewski
+This file is part of AstraDesk.
+
+AstraDesk is licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for the full license text.
+-->
+
 # ISSUES_NEW-03 — API implementation-contract conformance (NEW)
 
 - **Track / Milestone**: A / `v0.4.0`

--- a/docs/roadmap/issues/ISSUES_NEW-04_pii_egress_boundary.md
+++ b/docs/roadmap/issues/ISSUES_NEW-04_pii_egress_boundary.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+Project: AstraDesk
+File: docs/roadmap/issues/ISSUES_NEW-04_pii_egress_boundary.md
+Website: https://www.astradesk.dev
+Repository: https://github.com/SSobol77/astradesk
+
+Description: Documents AstraDesk architecture, operation, or component behavior.
+
+Copyright (c) 2026 Siergej Sobolewski
+This file is part of AstraDesk.
+
+AstraDesk is licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for the full license text.
+-->
+
 # ISSUES_NEW-04 — Ingress PII/secret redaction & egress boundary (NEW)
 
 - **Track / Milestone**: A / `v0.3.1`

--- a/docs/roadmap/issues/ISSUES_NEW-04_pii_egress_boundary.md
+++ b/docs/roadmap/issues/ISSUES_NEW-04_pii_egress_boundary.md
@@ -1,0 +1,47 @@
+# ISSUES_NEW-04 — Ingress PII/secret redaction & egress boundary (NEW)
+
+- **Track / Milestone**: A / `v0.3.1`
+- **Type**: NEW
+- **Workhorse principle**: Security (good-sense)
+- **GA-gating**: yes — a client's data must not leak through our telemetry or tool/model calls
+- **Audit anchors**: §7 (Critical); `mcp/src/gateway/middleware.py:96-110`; `services/api-gateway/src/model_gateway/guardrails.py:70-89`; `services/api-gateway/src/runtime/rag.py:329-333`
+- **Depends on**: ISSUE 009 (a request identity to attach classification to)
+- **Independent of**: OPA policy authoring (028)
+
+## Problem (current evidence)
+The PII middleware is a no-op. Model guardrails record a raw input preview **before** redaction. RAG traces raw query text into span attributes. PII/secrets can therefore enter logs, traces, external model calls, and external tools with no ingress boundary.
+
+## Industry analog & childhood disease
+PII-naive RAG/LLM stacks leak user data into trace attributes, prompt logs, and the vector store, then discover it during a compliance review. The disease is **"observe first, redact later"** — telemetry is added for debugging and quietly becomes an exfiltration path. We immunize with redact-before-emit and an explicit egress allow-list.
+
+## Target contract (invariants)
+- **INV-PII-1 (INV-NO-RAW-EGRESS)**: No raw user input reaches a log line, span attribute, external model, or external tool before classification + redaction.
+- **INV-PII-2**: Data classification is attached at ingress and propagates with the request; downstream emitters consult it.
+- **INV-PII-3**: Egress targets (models, tools, sinks) are governed by an allow-list; an unlisted target is denied.
+- **INV-PII-4**: Redaction is applied to span attributes and structured logs at the emitter, not optionally at the call site.
+
+## Interface / design
+- Replace the no-op middleware with a real ingress classifier (configurable detectors: emails, tokens/secrets, keys, configurable regex packs).
+- A redaction utility used by the tracing/logging layer so raw text cannot be set as a span attribute.
+- Egress allow-list config consulted by model_gateway and tool adapters.
+
+## Failure modes & required behavior
+| Failure | Required behavior |
+| :--- | :--- |
+| Secret/email/key in user input | Redacted token in logs/traces; original never emitted |
+| New emitter added without redaction | Lint/test fails (no raw attribute setter on user text) |
+| Egress to unlisted external target | Denied + audited |
+| Redactor throws | Fail-closed: drop the field, do not emit raw |
+
+## Acceptance criteria (Definition of Done)
+- [ ] Ingress classifier active; no-op middleware removed.
+- [ ] Representative PII/secret corpus → asserted absent from logs, span attributes, model payloads, and tool payloads.
+- [ ] RAG query and guardrail preview redacted before tracing.
+- [ ] Egress allow-list enforced with a negative test (unlisted target denied).
+- [ ] Static check forbidding raw user text as a span attribute.
+
+## Verification evidence (artifact)
+Leak-corpus test report (zero-leak assertion); egress negative test log.
+
+## Out of scope
+Full DLP product integration, tokenization vault (Track B).

--- a/docs/roadmap/issues/ISSUES_NEW-05_rag_isolation_slo.md
+++ b/docs/roadmap/issues/ISSUES_NEW-05_rag_isolation_slo.md
@@ -1,0 +1,49 @@
+# ISSUES_NEW-05 — RAG/embedding isolation & SLO qualification (NEW)
+
+- **Track / Milestone**: B / `v0.5.0`
+- **Type**: NEW
+- **Workhorse principle**: Security/robustness via fault containment (enterprise direction)
+- **GA-gating**: GA-direction (not the Workhorse v1 gate); reserved by interface now
+- **Audit anchors**: §6 (High); `services/api-gateway/src/runtime/rag.py:100-145`, `311-355`; `services/api-gateway/src/gateway/main.py:119-184`; `.claude/PIPLINE.md:20`
+- **Depends on**: NEW-02 (reproducible images), NEW-03 (stable contracts to extend with an RPC boundary)
+
+## Problem (current evidence)
+The API Gateway constructs `SentenceTransformer` in-process during lifespan and performs model placement at startup; retrieval computes the same query embedding twice (before and inside the traced block). A single process owns request admission, DB/Redis clients, BM25, model memory, and embedding compute. SLO targets (p95 ≤ 8s, tool success ≥ 95%) are documented but not enforced by any load/canary test.
+
+## Industry analog & childhood disease
+RAG stacks that embed inference in the request process suffer cold-start nondeterminism (model download blocks readiness), OOM under concurrency, GPU/CPU contention, and a single fault domain that takes the whole gateway down. The disease is **co-locating heavy ML with request admission "to ship faster,"** then being unable to scale or isolate failures. We immunize by splitting embedding/RAG into a bounded, separately scaled worker and proving degraded behavior under load.
+
+## Target contract (invariants)
+- **INV-RAG-1**: Embedding/RAG execution lives behind a bounded RPC contract in a separately scaled worker; the Gateway holds no model in-process.
+- **INV-RAG-2**: Gateway liveness is independent of model/worker readiness; readiness states are explicit.
+- **INV-RAG-3**: Each query embedding is computed **once** per request; cache hit/miss paths do not recompute.
+- **INV-RAG-4**: The RPC contract defines timeout, queue bound, cancellation, and overload (backpressure/reject) behavior.
+- **INV-RAG-5**: p95 latency and tool-success SLOs are asserted by executable load + fault-injection tests, not documentation.
+
+## Interface / design
+- Extract embedding/retrieval into a worker service with a typed RPC contract (bounded concurrency, timeouts).
+- Pre-bake model artifacts into the worker image; Gateway calls the worker.
+- Remove duplicate inference; single compute passed into search.
+- k6/Locust workloads + dependency fault injection in CI/perf stage with percentile assertions.
+
+## Failure modes & required behavior
+| Failure | Required behavior |
+| :--- | :--- |
+| Worker overloaded | Backpressure/reject with bounded latency, not unbounded queue |
+| Worker unavailable | Gateway stays live; RAG path degrades explicitly |
+| Model download slow at start | Worker readiness gated; Gateway readiness independent |
+| Request cancelled | Embedding/search cancelled, resources released |
+| p95 regression | Perf gate fails |
+
+## Acceptance criteria (Definition of Done)
+- [ ] No ML model loaded in the Gateway process; embedding behind RPC.
+- [ ] Single embedding compute per request (hit + miss covered).
+- [ ] Timeout/queue/cancellation/overload behavior implemented and tested.
+- [ ] Load + fault-injection suite asserts p95 ≤ target and tool-success ≥ target.
+- [ ] Gateway readiness independent of worker/model readiness.
+
+## Verification evidence (artifact)
+Load-test report with percentile assertions; fault-injection results; cold-start readiness log.
+
+## Out of scope
+Model selection/quality tuning, multi-model routing, Ragas quality eval (#26).

--- a/docs/roadmap/issues/ISSUES_NEW-05_rag_isolation_slo.md
+++ b/docs/roadmap/issues/ISSUES_NEW-05_rag_isolation_slo.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+Project: AstraDesk
+File: docs/roadmap/issues/ISSUES_NEW-05_rag_isolation_slo.md
+Website: https://www.astradesk.dev
+Repository: https://github.com/SSobol77/astradesk
+
+Description: Documents AstraDesk architecture, operation, or component behavior.
+
+Copyright (c) 2026 Siergej Sobolewski
+This file is part of AstraDesk.
+
+AstraDesk is licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for the full license text.
+-->
+
 # ISSUES_NEW-05 — RAG/embedding isolation & SLO qualification (NEW)
 
 - **Track / Milestone**: B / `v0.5.0`

--- a/docs/roadmap/issues/ISSUES_NEW-06_backup_restore_dr.md
+++ b/docs/roadmap/issues/ISSUES_NEW-06_backup_restore_dr.md
@@ -1,0 +1,48 @@
+# ISSUES_NEW-06 — Backup/restore & disaster-recovery evidence (NEW)
+
+- **Track / Milestone**: B / `v0.6.0`
+- **Type**: NEW
+- **Workhorse principle**: Operational resilience (enterprise direction)
+- **GA-gating**: GA-direction (not the Workhorse v1 gate)
+- **Audit anchors**: §8; `docs/operations.md:360-390`; relates to ISSUE 019 (durable audit) and issue #24 (alerts)
+- **Depends on**: ISSUE 019 (audit durability), NEW-02 (reproducible infra)
+
+## Problem (current evidence)
+Disaster-recovery content is prose without executable restore procedures or drill results. There is no documented, tested backup/restore for Postgres (agent memory + RAG/pgvector state) or audit storage, and no measured RPO/RTO or named decision authority.
+
+## Industry analog & childhood disease
+Teams document a DR plan, schedule backups, and never test a restore — then discover during a real incident that the backup is unrestorable, the extension/state is incomplete, or nobody is authorized to trigger failover. The disease is **"DR on paper"**: backups that were never proven to restore, with unknown recovery time. We immunize by requiring an **executed, timed restore drill** as the acceptance evidence, not a written procedure.
+
+## Target contract (invariants)
+- **INV-DR-1**: Every stateful store (Postgres memory, pgvector RAG state, audit sink) has a backup whose **restore is executed and verified**, not merely scheduled.
+- **INV-DR-2**: Restore is idempotent and produces a verifiable post-restore integrity check (row/vector/audit counts and a functional probe).
+- **INV-DR-3**: Measured **RPO** (max data-loss window) and **RTO** (restore duration) are recorded from a real drill.
+- **INV-DR-4**: pgvector extension/state restores correctly on the pinned image (ties to NEW-02 baseline).
+- **INV-DR-5**: A named decision authority and runbook trigger exist for invoking recovery.
+
+## Interface / design
+- Backup jobs for Postgres (incl. pgvector) and audit storage with retention policy.
+- A repeatable restore script run against an empty target; post-restore integrity probe.
+- Drill procedure capturing timestamps to compute RPO/RTO; recorded in ops docs.
+
+## Failure modes & required behavior
+| Failure | Required behavior |
+| :--- | :--- |
+| Backup exists but restore fails | Drill fails; not "done" until restore verified |
+| pgvector state missing post-restore | Integrity probe fails |
+| Restore exceeds RTO target | Recorded as a gap with remediation |
+| Audit gap exceeds RPO | Recorded; tie to ISSUE 019 durability |
+| No authorized operator | Runbook defines authority before GA |
+
+## Acceptance criteria (Definition of Done)
+- [ ] Executed restore drill for Postgres + pgvector + audit storage on an empty target.
+- [ ] Post-restore integrity probe passes (counts + functional check).
+- [ ] Measured RPO/RTO recorded from the drill.
+- [ ] Runbook with decision authority and trigger steps published.
+- [ ] Restore verified on the pinned baseline image.
+
+## Verification evidence (artifact)
+Drill log with RPO/RTO timestamps; integrity-probe output; restore runbook.
+
+## Out of scope
+Multi-region active-active, automated failover orchestration, chaos-engineering program (future).

--- a/docs/roadmap/issues/ISSUES_NEW-06_backup_restore_dr.md
+++ b/docs/roadmap/issues/ISSUES_NEW-06_backup_restore_dr.md
@@ -1,3 +1,19 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+Project: AstraDesk
+File: docs/roadmap/issues/ISSUES_NEW-06_backup_restore_dr.md
+Website: https://www.astradesk.dev
+Repository: https://github.com/SSobol77/astradesk
+
+Description: Documents AstraDesk architecture, operation, or component behavior.
+
+Copyright (c) 2026 Siergej Sobolewski
+This file is part of AstraDesk.
+
+AstraDesk is licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for the full license text.
+-->
+
 # ISSUES_NEW-06 — Backup/restore & disaster-recovery evidence (NEW)
 
 - **Track / Milestone**: B / `v0.6.0`

--- a/docs/roadmap/issues/ISSUE_009_evidence.txt
+++ b/docs/roadmap/issues/ISSUE_009_evidence.txt
@@ -1,0 +1,12 @@
+# ISSUE 009 — verification evidence
+Date: 2026-06-28T15:42:03Z
+Toolchain: pyjwt 2.7.0, fastapi 0.138.1, mypy/ruff current
+
+## ruff
+All checks passed!
+
+## mypy
+Success: no issues found in 2 source files
+
+## pytest (14 verifier negative-matrix + 4 FastAPI dependency 401-mapping)
+18 passed, 1 warning in 0.42s

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,7 @@ site_description: "AstraDesk Enterprise AI Agents Framework — Technical Guide 
 site_url: https://astradesk.vercel.app
 repo_url: https://github.com/SSobol77/astradesk
 repo_name: SSobol77/astradesk
-copyright: "© 2025 AstraDesk"
+copyright: "© 2025-2026 AstraDesk"
 
 docs_dir: docs
 
@@ -32,6 +32,8 @@ exclude_docs: |
   pl/README.pl.main.md
   pl/README.pl.md
   zh-CN/README.zh-CN.main.md
+  roadmap/issues/
+  roadmap/engineering_task.md
 
 theme:
   name: material
@@ -89,7 +91,7 @@ plugins:
 
 extra_javascript:
   - https://unpkg.com/mermaid@10/dist/mermaid.min.js
-  - js/mermaid-init.js 
+  - js/mermaid-init.js
 
 extra_css:
   - styles/mermaid-card.css
@@ -100,6 +102,7 @@ watch:
 
 nav:
   - Home: README.md
+  - Roadmap: roadmap/index.md
 
   - Guides (EN):
       - Introduction: en/01_introduction.md
@@ -134,7 +137,6 @@ nav:
 
   - API (Redoc):
       - Admin API v1.2.0 — Reference: api/index.md
-
 
 extra:
   social:

--- a/scripts/seed-tracker.sh
+++ b/scripts/seed-tracker.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
 # File: scripts/seed-tracker.sh
-# Purpose: Idempotently seed AstraDesk tracker for the v0.3.1 Safety Core plan.
-#   - additive milestone v0.3.1 (touches no historical milestone)
-#   - labels (track-a/track-b/supply-chain)
-#   - new issues with contract-file references
-#   - retarget OPEN #28 to v0.3.1 (rescope)
-#   - cross-link follow-ups on CLOSED #9/#16/#19 (never reopened)
-#   - track tagging of existing issues
-# Safe to re-run: every create is guarded; comments are posted at most once.
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
 #
-# Requires: gh (authenticated with repo write), jq.
-# This script performs TRACKER writes only. It does NOT touch git history.
+# Description: Automates AstraDesk development, deployment, or operational tasks.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
 set -euo pipefail
 
 REPO="${REPO:-SSobol77/astradesk}"

--- a/scripts/seed-tracker.sh
+++ b/scripts/seed-tracker.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-only
+# File: scripts/seed-tracker.sh
+# Purpose: Idempotently seed AstraDesk tracker for the v0.3.1 Safety Core plan.
+#   - additive milestone v0.3.1 (touches no historical milestone)
+#   - labels (track-a/track-b/supply-chain)
+#   - new issues with contract-file references
+#   - retarget OPEN #28 to v0.3.1 (rescope)
+#   - cross-link follow-ups on CLOSED #9/#16/#19 (never reopened)
+#   - track tagging of existing issues
+# Safe to re-run: every create is guarded; comments are posted at most once.
+#
+# Requires: gh (authenticated with repo write), jq.
+# This script performs TRACKER writes only. It does NOT touch git history.
+set -euo pipefail
+
+REPO="${REPO:-SSobol77/astradesk}"
+MILESTONE="v0.3.1 - Commercial Workhorse Hardening"
+MILESTONE_DUE="2026-07-25T23:59:59Z"
+ISSUES_DIR="docs/roadmap/issues"
+
+command -v gh >/dev/null || { echo "FATAL: gh not found" >&2; exit 1; }
+command -v jq >/dev/null || { echo "FATAL: jq not found" >&2; exit 1; }
+
+log() { printf '  %s\n' "$*"; }
+
+# --- helpers -----------------------------------------------------------------
+
+ensure_label() {
+  # ensure_label <name> <color> <description>
+  local name="$1" color="$2" desc="${3:-}"
+  if gh label list --repo "$REPO" --json name --jq '.[].name' | grep -qx "$name"; then
+    log "label exists: $name"
+  else
+    gh label create "$name" --repo "$REPO" --color "$color" --description "$desc"
+    log "label created: $name"
+  fi
+}
+
+ensure_milestone() {
+  # ensure_milestone <title> <due_on_iso> <description>
+  local title="$1" due="$2" desc="$3"
+  local num
+  num="$(gh api "repos/$REPO/milestones?state=all&per_page=100" \
+        --jq ".[] | select(.title==\"$title\") | .number" | head -n1)"
+  if [[ -n "${num:-}" ]]; then
+    log "milestone exists: $title (#$num)"
+  else
+    gh api "repos/$REPO/milestones" -X POST \
+      -f title="$title" -f state=open -f due_on="$due" -f description="$desc" >/dev/null
+    log "milestone created: $title"
+  fi
+}
+
+issue_number_by_title() {
+  # exact-title match across all states; prints number or empty
+  local title="$1"
+  gh issue list --repo "$REPO" --state all --search "in:title \"$title\"" \
+    --json number,title --jq ".[] | select(.title==\"$title\") | .number" | head -n1
+}
+
+ensure_issue() {
+  # ensure_issue <title> <milestone-title> <labels-csv> <body>
+  local title="$1" ms="$2" labels="$3" body="$4"
+  local num; num="$(issue_number_by_title "$title")"
+  if [[ -n "${num:-}" ]]; then
+    log "issue exists: #$num $title"
+  else
+    gh issue create --repo "$REPO" --title "$title" \
+      --milestone "$ms" --label "$labels" --body "$body" >/dev/null
+    log "issue created: $title"
+  fi
+}
+
+comment_once() {
+  # comment_once <issue-number> <marker> <body>  (marker must be embedded in body)
+  local num="$1" marker="$2" body="$3"
+  if gh issue view "$num" --repo "$REPO" --json comments \
+       --jq '.comments[].body' 2>/dev/null | grep -qF "$marker"; then
+    log "comment present on #$num (marker: $marker)"
+  else
+    gh issue comment "$num" --repo "$REPO" --body "$body" >/dev/null
+    log "comment posted on #$num"
+  fi
+}
+
+retarget_open_issue() {
+  # retarget_open_issue <number> <milestone-title> <add-label>
+  local num="$1" ms="$2" lbl="$3"
+  gh issue edit "$num" --repo "$REPO" --milestone "$ms" --add-label "$lbl" >/dev/null
+  log "retargeted #$num -> $ms (+$lbl)"
+}
+
+add_label() { gh issue edit "$1" --repo "$REPO" --add-label "$2" >/dev/null && log "labeled #$1 +$2"; }
+
+# --- 1. labels ---------------------------------------------------------------
+echo "[1/6] labels"
+ensure_label track-a        0E8A16 "Commercial workhorse gate"
+ensure_label track-b        1D76DB "Enterprise direction"
+ensure_label supply-chain   B60205 "Dependency / supply-chain security"
+# Guards for every label referenced by ensure_issue below. ensure_label is
+# idempotent: pre-existing repo labels are detected and left untouched.
+ensure_label security       D73A4A "Security and safety controls"
+ensure_label authentication 5319E7 "Authentication, OIDC, JWT, identity"
+ensure_label rbac           5319E7 "Role-based access control"
+ensure_label devops         0E8A16 "Build, deployment, and infrastructure"
+ensure_label testing        F9D0C4 "Tests, gates, and verification evidence"
+
+# --- 2. additive milestone ---------------------------------------------------
+echo "[2/6] milestone"
+ensure_milestone "$MILESTONE" "$MILESTONE_DUE" \
+"Track A gate to first commercial client: OIDC at active ingress, invariant per-tool RBAC on LLM+fallback paths, PII/egress boundary, durable audit, fail-closed OPA, secret removal, reachable-vuln remediation, reproducible build, executable integration gate. Additive; alters no historical milestone."
+
+# --- 3. new v0.3.1 issues (reference contract files) -------------------------
+echo "[3/6] v0.3.1 issues"
+ensure_issue "Wire JWKS/OIDC at active ingress" "$MILESTONE" "security,authentication,track-a" \
+"Hardening follow-up to #9. Contract: $ISSUES_DIR/ISSUES_009_oidc_ingress.md
+Fail-closed JWKS; HS256 only behind explicit local mode. Enforces INV-DUAL-PATH identity."
+ensure_issue "RBAC invariant on every side-effect path" "$MILESTONE" "security,rbac,track-a" \
+"Follow-up to #16. Contract: $ISSUES_DIR/ISSUES_016_rbac_invariant.md
+Deny-by-default; dual-path (LLM+fallback) negative matrix. Central INV-DUAL-PATH control."
+ensure_issue "Durable, recoverable audit (JetStream)" "$MILESTONE" "security,track-a" \
+"Follow-up to #19. Contract: $ISSUES_DIR/ISSUES_019_durable_audit.md
+Ack-after-durable-write, DLQ, crash-recovery test."
+ensure_issue "Dependency & supply-chain remediation" "$MILESTONE" "security,supply-chain,track-a" \
+"NEW-01. Contract: $ISSUES_DIR/ISSUES_NEW-01_supply_chain.md
+Reachability triage; CI scan gate fail-closed."
+ensure_issue "Reproducible containers, valid Compose, one baseline" "$MILESTONE" "devops,track-a" \
+"NEW-02. Contract: $ISSUES_DIR/ISSUES_NEW-02_reproducible_build.md
+uv.lock builds, Python 3.13, non-root, pinned digests."
+ensure_issue "Ingress PII/secret redaction & egress boundary" "$MILESTONE" "security,track-a" \
+"NEW-04. Contract: $ISSUES_DIR/ISSUES_NEW-04_pii_egress_boundary.md
+Redact-before-emit; egress allow-list."
+ensure_issue "Verify Helm/Terraform/Istio deployability (remove UNVERIFIED)" "$MILESTONE" "devops,testing,track-a" \
+"Consolidates residual validation from #5/#12/#15/#17: helm lint/template/install, terraform validate/plan, istioctl analyze + negative-connectivity."
+
+# --- 4. retarget OPEN #28 (rescope) ------------------------------------------
+echo "[4/6] retarget #28 (OPA)"
+retarget_open_issue 28 "$MILESTONE" track-a
+comment_once 28 "[seed-tracker:rescope-028]" \
+"[seed-tracker:rescope-028] RESCOPE -> deployable fail-closed OPA + schema-hash pinning (v0.3.1). Contract: $ISSUES_DIR/ISSUES_028_opa_fail_closed.md. Advanced policy-authoring UX deferred to Track B."
+
+# --- 5. follow-up cross-links on CLOSED issues (never reopened) ---------------
+echo "[5/6] follow-up comments on closed #9/#16/#19"
+comment_once 9  "[seed-tracker:followup-9]" \
+"[seed-tracker:followup-9] Residual hardening tracked as new v0.3.1 issue 'Wire JWKS/OIDC at active ingress'. #9 stays closed (original deliverable shipped)."
+comment_once 16 "[seed-tracker:followup-16]" \
+"[seed-tracker:followup-16] Residual hardening tracked as new v0.3.1 issue 'RBAC invariant on every side-effect path'. #16 stays closed."
+comment_once 19 "[seed-tracker:followup-19]" \
+"[seed-tracker:followup-19] Residual hardening tracked as new v0.3.1 issue 'Durable, recoverable audit'. #19 stays closed (subscriber exists; durability is new scope)."
+
+# --- 6. track tagging + Track B new issues -----------------------------------
+echo "[6/6] track tagging + Track B issues"
+for i in 18 21 23 24; do add_label "$i" track-a; done
+for i in 25 26 27;    do add_label "$i" track-b; done
+
+ensure_issue "API implementation-contract conformance" "v0.4.0 - AI-Powered Enhancements" "track-a" \
+"NEW-03. Contract: $ISSUES_DIR/ISSUES_NEW-03_contract_conformance.md
+Gateway route /v1/run vs docs; Admin API structural diff (42 path-templates, 2 extra ops)."
+ensure_issue "RAG/embedding isolation & SLO qualification" "v0.5.0 - Enterprise-Grade Features" "track-b" \
+"NEW-05. Contract: $ISSUES_DIR/ISSUES_NEW-05_rag_isolation_slo.md
+Split embedding from Gateway; bounded RPC; load/fault-injection SLO gate."
+ensure_issue "Backup/restore & DR evidence (RPO/RTO)" "v0.6.0 - Advanced Features and Polish" "track-b" \
+"NEW-06. Contract: $ISSUES_DIR/ISSUES_NEW-06_backup_restore_dr.md
+Executed restore drills; measured RPO/RTO; runbook with decision authority."
+
+echo "Done. Re-running this script is safe (idempotent)."

--- a/services/api-gateway/src/gateway/auth_dependency.py
+++ b/services/api-gateway/src/gateway/auth_dependency.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# File: services/api-gateway/src/gateway/auth_dependency.py
+#
+# FastAPI binding for the OIDC ingress verifier (ISSUE 009).
+#
+# The verifier is built once at startup (fail-closed) and stored on app.state.
+# This dependency extracts the bearer token, verifies it, and attaches the
+# resulting Principal to request.state for the downstream RBAC choke point
+# (ISSUE 016). It deliberately holds NO verification logic of its own.
+from __future__ import annotations
+
+from astradesk_core.utils.oidc import (
+    AuthError,
+    Principal,
+    Verifier,
+    build_verifier_from_env,
+)
+from fastapi import FastAPI, Request
+from fastapi.exceptions import HTTPException
+from starlette.status import HTTP_401_UNAUTHORIZED
+
+__all__ = ["get_principal", "install_verifier", "require_authenticated"]
+
+_BEARER_PREFIX = "bearer "
+
+
+def install_verifier(app: FastAPI) -> None:
+    """Build and attach the verifier during startup.
+
+    Call from the lifespan/startup handler. Raises AuthConfigError if required
+    auth configuration is missing, which aborts process start (fail-closed).
+    """
+    app.state.token_verifier = build_verifier_from_env()
+
+
+def _extract_bearer(request: Request) -> str:
+    header = request.headers.get("authorization", "")
+    if not header or not header.lower().startswith(_BEARER_PREFIX):
+        raise AuthError("missing_token", "missing or malformed Authorization header")
+    return header[len(_BEARER_PREFIX) :].strip()
+
+
+async def require_authenticated(request: Request) -> Principal:
+    """Ingress auth dependency. Use as ``Depends(require_authenticated)``.
+
+    On success: returns the Principal and stores it on request.state.principal.
+    On failure: 401 with a stable WWW-Authenticate error code; the detail body
+    never echoes token contents.
+    """
+    verifier: Verifier = request.app.state.token_verifier
+    try:
+        token = _extract_bearer(request)
+        principal = verifier.verify(token)
+    except AuthError as exc:
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail={"error": exc.code},
+            headers={"WWW-Authenticate": f'Bearer error="{exc.code}"'},
+        ) from exc
+    request.state.principal = principal
+    return principal
+
+
+def get_principal(request: Request) -> Principal:
+    """Retrieve the Principal attached by require_authenticated (downstream use)."""
+    principal = getattr(request.state, "principal", None)
+    if principal is None:
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED, detail={"error": "unauthenticated"}
+        )
+    return principal

--- a/services/api-gateway/src/gateway/auth_dependency.py
+++ b/services/api-gateway/src/gateway/auth_dependency.py
@@ -1,12 +1,18 @@
 # SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
 # File: services/api-gateway/src/gateway/auth_dependency.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
 #
-# FastAPI binding for the OIDC ingress verifier (ISSUE 009).
+# Description: Implements AstraDesk functionality for services/api-gateway/src/gateway/auth_dependency.py.
 #
-# The verifier is built once at startup (fail-closed) and stored on app.state.
-# This dependency extracts the bearer token, verifies it, and attaches the
-# resulting Principal to request.state for the downstream RBAC choke point
-# (ISSUE 016). It deliberately holds NO verification logic of its own.
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
 from __future__ import annotations
 
 from astradesk_core.utils.oidc import (

--- a/services/api-gateway/src/gateway/auth_dependency.py
+++ b/services/api-gateway/src/gateway/auth_dependency.py
@@ -25,9 +25,9 @@ from fastapi import FastAPI, Request
 from fastapi.exceptions import HTTPException
 from starlette.status import HTTP_401_UNAUTHORIZED
 
-__all__ = ["get_principal", "install_verifier", "require_authenticated"]
+__all__ = ['get_principal', 'install_verifier', 'require_authenticated']
 
-_BEARER_PREFIX = "bearer "
+_BEARER_PREFIX = 'bearer '
 
 
 def install_verifier(app: FastAPI) -> None:
@@ -40,9 +40,9 @@ def install_verifier(app: FastAPI) -> None:
 
 
 def _extract_bearer(request: Request) -> str:
-    header = request.headers.get("authorization", "")
+    header = request.headers.get('authorization', '')
     if not header or not header.lower().startswith(_BEARER_PREFIX):
-        raise AuthError("missing_token", "missing or malformed Authorization header")
+        raise AuthError('missing_token', 'missing or malformed Authorization header')
     return header[len(_BEARER_PREFIX) :].strip()
 
 
@@ -60,8 +60,8 @@ async def require_authenticated(request: Request) -> Principal:
     except AuthError as exc:
         raise HTTPException(
             status_code=HTTP_401_UNAUTHORIZED,
-            detail={"error": exc.code},
-            headers={"WWW-Authenticate": f'Bearer error="{exc.code}"'},
+            detail={'error': exc.code},
+            headers={'WWW-Authenticate': f'Bearer error="{exc.code}"'},
         ) from exc
     request.state.principal = principal
     return principal
@@ -69,9 +69,7 @@ async def require_authenticated(request: Request) -> Principal:
 
 def get_principal(request: Request) -> Principal:
     """Retrieve the Principal attached by require_authenticated (downstream use)."""
-    principal = getattr(request.state, "principal", None)
+    principal = getattr(request.state, 'principal', None)
     if principal is None:
-        raise HTTPException(
-            status_code=HTTP_401_UNAUTHORIZED, detail={"error": "unauthenticated"}
-        )
+        raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail={'error': 'unauthenticated'})
     return principal

--- a/services/api-gateway/src/gateway/main.py
+++ b/services/api-gateway/src/gateway/main.py
@@ -25,7 +25,6 @@ This module sets up the FastAPI application, including:
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import uuid
@@ -43,9 +42,8 @@ from agents.base import BaseAgent
 from agents.billing import BillingAgent
 from agents.ops import OpsAgent
 from agents.support import SupportAgent
+from astradesk_core.utils.oidc import Principal
 from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from jose import JWTError, jwt
 from model_gateway.llm_planner import LLMPlanner
 from model_gateway.router import provider_router
 from opa_client.opa import OpaClient
@@ -60,6 +58,7 @@ import asyncpg
 import redis.asyncio as redis
 
 # AstraDesk imports
+from gateway.auth_dependency import install_verifier, require_authenticated
 from gateway.orchestrator import AgentNotFoundError, AgentOrchestrator, PolicyViolationError
 
 # --- Configuration ---
@@ -76,44 +75,10 @@ _DEFAULT_REDIS_URL = 'redis://localhost:6379/0'
 DATABASE_URL = os.getenv('DATABASE_URL', _DEFAULT_DATABASE_URL)
 REDIS_URL = os.getenv('REDIS_URL', _DEFAULT_REDIS_URL)
 OPA_URL = os.getenv('OPA_URL', 'http://localhost:8181')
-JWT_SECRET_KEY = os.getenv('JWT_SECRET_KEY', 'super-secret-key-for-dev')
-JWT_ALGORITHM = os.getenv('JWT_ALGORITHM', 'HS256')
 
 # --- Global State ---
 # Use a dictionary for state to avoid global variables
 app_state: dict[str, Any] = {}
-http_bearer = HTTPBearer(
-    description='Bearer token for authentication with JWT claims.',
-    scheme_name='Bearer',
-)
-
-
-# --- Authentication ---
-async def get_current_user_claims(
-    token: HTTPAuthorizationCredentials = Depends(http_bearer),
-) -> dict[str, Any]:
-    """
-    Dependency to decode and validate JWT, returning user claims.
-    This is a best-practice user loader function.
-    """
-    credentials_exception = HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail='Could not validate credentials',
-        headers={'WWW-Authenticate': 'Bearer'},
-    )
-    try:
-        payload = jwt.decode(token.credentials, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
-        if 'sub' not in payload or 'roles' not in payload:
-            raise credentials_exception
-        await asyncio.sleep(0)
-        return payload
-    except JWTError:
-        raise credentials_exception
-    except Exception:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail='An error occurred while processing credentials.',
-        )
 
 
 # --- Application Lifespan (Startup/Shutdown) ---
@@ -123,6 +88,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     Handles application startup and shutdown events to manage resources.
     """
     logger.info('API Gateway starting up...')
+    install_verifier(app)
 
     # --- Initialize connections ---
     # DATABASE_URL/REDIS_URL always resolve (to real values or safe dummy
@@ -282,7 +248,7 @@ async def proxy_to_admin_service(request: Request) -> Response:
 async def execute_agent(
     agent_request: AgentRequest,
     request: Request,
-    claims: dict[str, Any] = Depends(get_current_user_claims),
+    principal: Principal = Depends(require_authenticated),
 ) -> AgentResponse:
     """
     Main endpoint to run an agent.
@@ -300,7 +266,7 @@ async def execute_agent(
     request_id = request.headers.get('X-Request-ID', str(uuid.uuid4()))
 
     try:
-        response = await orchestrator.run(agent_request, claims, request_id)
+        response = await orchestrator.run(agent_request, dict(principal.claims), request_id)
         return response
     except AgentNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/services/api-gateway/tests/runtime/test_auth_dependency.py
+++ b/services/api-gateway/tests/runtime/test_auth_dependency.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# File: services/api-gateway/tests/runtime/test_auth_dependency.py
+#
+# FastAPI boundary tests for the ingress auth dependency (ISSUE 009).
+#
+# Proves: a bad/absent token yields 401 and the handler never executes; a valid
+# token reaches the handler and the Principal is attached to request.state.
+from __future__ import annotations
+
+from astradesk_core.utils.oidc import AuthError, Principal
+from fastapi import Depends, FastAPI, Request
+from fastapi.testclient import TestClient
+from gateway.auth_dependency import get_principal, require_authenticated
+
+HANDLER_MARKER = {"handler_ran": True}
+
+
+class _FakeVerifier:
+    """Deterministic stand-in for the real verifier on app.state."""
+
+    def __init__(self, principal: Principal | None = None, error: AuthError | None = None):
+        self._principal = principal
+        self._error = error
+
+    def verify(self, token: str) -> Principal:
+        if self._error is not None:
+            raise self._error
+        assert self._principal is not None
+        return self._principal
+
+
+def _make_app(verifier: _FakeVerifier) -> FastAPI:
+    app = FastAPI()
+    app.state.token_verifier = verifier
+
+    @app.get("/protected")
+    async def protected(
+        request: Request, principal: Principal = Depends(require_authenticated)
+    ):
+        # Reaching here means the gate let the request through.
+        attached = get_principal(request)
+        return {"handler_ran": True, "sub": principal.subject, "attached": attached.subject}
+
+    return app
+
+
+_VALID_PRINCIPAL = Principal(subject="user-1", roles=("operator",), scopes=(), claims={})
+
+
+def test_missing_header_returns_401_and_skips_handler():
+    client = TestClient(_make_app(_FakeVerifier(principal=_VALID_PRINCIPAL)))
+    resp = client.get("/protected")
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["error"] == "missing_token"
+
+
+def test_malformed_header_returns_401():
+    client = TestClient(_make_app(_FakeVerifier(principal=_VALID_PRINCIPAL)))
+    resp = client.get("/protected", headers={"Authorization": "Token abc"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["error"] == "missing_token"
+
+
+def test_verifier_autherror_maps_to_401():
+    bad = _FakeVerifier(error=AuthError("token_expired", "expired"))
+    client = TestClient(_make_app(bad))
+    resp = client.get("/protected", headers={"Authorization": "Bearer x.y.z"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["error"] == "token_expired"
+    assert resp.headers.get("WWW-Authenticate") == 'Bearer error="token_expired"'
+
+
+def test_valid_token_reaches_handler_and_attaches_principal():
+    client = TestClient(_make_app(_FakeVerifier(principal=_VALID_PRINCIPAL)))
+    resp = client.get("/protected", headers={"Authorization": "Bearer good.token"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"handler_ran": True, "sub": "user-1", "attached": "user-1"}

--- a/services/api-gateway/tests/runtime/test_auth_dependency.py
+++ b/services/api-gateway/tests/runtime/test_auth_dependency.py
@@ -20,7 +20,7 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.testclient import TestClient
 from gateway.auth_dependency import get_principal, require_authenticated
 
-HANDLER_MARKER = {"handler_ran": True}
+HANDLER_MARKER = {'handler_ran': True}
 
 
 class _FakeVerifier:
@@ -41,46 +41,44 @@ def _make_app(verifier: _FakeVerifier) -> FastAPI:
     app = FastAPI()
     app.state.token_verifier = verifier
 
-    @app.get("/protected")
-    async def protected(
-        request: Request, principal: Principal = Depends(require_authenticated)
-    ):
+    @app.get('/protected')
+    async def protected(request: Request, principal: Principal = Depends(require_authenticated)):
         # Reaching here means the gate let the request through.
         attached = get_principal(request)
-        return {"handler_ran": True, "sub": principal.subject, "attached": attached.subject}
+        return {'handler_ran': True, 'sub': principal.subject, 'attached': attached.subject}
 
     return app
 
 
-_VALID_PRINCIPAL = Principal(subject="user-1", roles=("operator",), scopes=(), claims={})
+_VALID_PRINCIPAL = Principal(subject='user-1', roles=('operator',), scopes=(), claims={})
 
 
 def test_missing_header_returns_401_and_skips_handler():
     client = TestClient(_make_app(_FakeVerifier(principal=_VALID_PRINCIPAL)))
-    resp = client.get("/protected")
+    resp = client.get('/protected')
     assert resp.status_code == 401
-    assert resp.json()["detail"]["error"] == "missing_token"
+    assert resp.json()['detail']['error'] == 'missing_token'
 
 
 def test_malformed_header_returns_401():
     client = TestClient(_make_app(_FakeVerifier(principal=_VALID_PRINCIPAL)))
-    resp = client.get("/protected", headers={"Authorization": "Token abc"})
+    resp = client.get('/protected', headers={'Authorization': 'Token abc'})
     assert resp.status_code == 401
-    assert resp.json()["detail"]["error"] == "missing_token"
+    assert resp.json()['detail']['error'] == 'missing_token'
 
 
 def test_verifier_autherror_maps_to_401():
-    bad = _FakeVerifier(error=AuthError("token_expired", "expired"))
+    bad = _FakeVerifier(error=AuthError('token_expired', 'expired'))
     client = TestClient(_make_app(bad))
-    resp = client.get("/protected", headers={"Authorization": "Bearer x.y.z"})
+    resp = client.get('/protected', headers={'Authorization': 'Bearer x.y.z'})
     assert resp.status_code == 401
-    assert resp.json()["detail"]["error"] == "token_expired"
-    assert resp.headers.get("WWW-Authenticate") == 'Bearer error="token_expired"'
+    assert resp.json()['detail']['error'] == 'token_expired'
+    assert resp.headers.get('WWW-Authenticate') == 'Bearer error="token_expired"'
 
 
 def test_valid_token_reaches_handler_and_attaches_principal():
     client = TestClient(_make_app(_FakeVerifier(principal=_VALID_PRINCIPAL)))
-    resp = client.get("/protected", headers={"Authorization": "Bearer good.token"})
+    resp = client.get('/protected', headers={'Authorization': 'Bearer good.token'})
     assert resp.status_code == 200
     body = resp.json()
-    assert body == {"handler_ran": True, "sub": "user-1", "attached": "user-1"}
+    assert body == {'handler_ran': True, 'sub': 'user-1', 'attached': 'user-1'}

--- a/services/api-gateway/tests/runtime/test_auth_dependency.py
+++ b/services/api-gateway/tests/runtime/test_auth_dependency.py
@@ -1,10 +1,18 @@
 # SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
 # File: services/api-gateway/tests/runtime/test_auth_dependency.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
 #
-# FastAPI boundary tests for the ingress auth dependency (ISSUE 009).
+# Description: Verifies AstraDesk behavior for the associated component.
 #
-# Proves: a bad/absent token yields 401 and the handler never executes; a valid
-# token reaches the handler and the Principal is attached to request.state.
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
 from __future__ import annotations
 
 from astradesk_core.utils.oidc import AuthError, Principal

--- a/services/api-gateway/tests/runtime/test_gateway_ingress.py
+++ b/services/api-gateway/tests/runtime/test_gateway_ingress.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# File: services/api-gateway/tests/runtime/test_gateway_ingress.py
+#
+# Active API Gateway ingress tests for ISSUE 009.
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from astradesk_core.utils.oidc import AuthError, Principal
+from fastapi.testclient import TestClient
+from gateway import main as gateway_main
+from runtime.models import AgentRequest, AgentResponse
+
+_AGENT_REQUEST = {
+    'agent': 'support',
+    'input': 'Check the active ingress authentication boundary.',
+    'meta': {},
+}
+
+_PRINCIPAL = Principal(
+    subject='operator-1',
+    roles=('operator',),
+    scopes=('agents:run',),
+    claims={'sub': 'operator-1', 'roles': ['operator'], 'scope': 'agents:run'},
+)
+
+_REQUEST_ID = '00000000-0000-4000-8000-000000000009'
+
+
+class _RecordingVerifier:
+    def __init__(self) -> None:
+        self.tokens: list[str] = []
+
+    def verify(self, token: str) -> Principal:
+        self.tokens.append(token)
+        if token != 'valid-token':
+            raise AuthError('invalid_token', 'test verifier rejected token')
+        return _PRINCIPAL
+
+
+class _RecordingOrchestrator:
+    def __init__(self) -> None:
+        self.calls: list[tuple[AgentRequest, dict[str, Any], str]] = []
+
+    async def run(
+        self, request: AgentRequest, claims: dict[str, Any], request_id: str
+    ) -> AgentResponse:
+        self.calls.append((request, claims, request_id))
+        return AgentResponse(
+            output='Ingress accepted the authenticated request.',
+            reasoning_trace_id=request_id,
+            invoked_tools=[],
+        )
+
+
+@pytest.fixture
+def ingress_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[tuple[TestClient, _RecordingVerifier, _RecordingOrchestrator]]:
+    verifier = _RecordingVerifier()
+    orchestrator = _RecordingOrchestrator()
+    monkeypatch.setattr(
+        gateway_main.app.state, 'token_verifier', verifier, raising=False
+    )
+    monkeypatch.setitem(gateway_main.app_state, 'orchestrator', orchestrator)
+    client = TestClient(gateway_main.app)
+    yield client, verifier, orchestrator
+    client.close()
+
+
+def test_missing_authorization_returns_401_before_handler(
+    ingress_client: tuple[TestClient, _RecordingVerifier, _RecordingOrchestrator],
+) -> None:
+    client, verifier, orchestrator = ingress_client
+
+    response = client.post('/v1/run', json=_AGENT_REQUEST)
+
+    assert response.status_code == 401
+    assert response.json()['detail']['error'] == 'missing_token'
+    assert verifier.tokens == []
+    assert orchestrator.calls == []
+
+
+def test_invalid_authorization_returns_401_before_handler(
+    ingress_client: tuple[TestClient, _RecordingVerifier, _RecordingOrchestrator],
+) -> None:
+    client, verifier, orchestrator = ingress_client
+
+    response = client.post(
+        '/v1/run',
+        json=_AGENT_REQUEST,
+        headers={'Authorization': 'Bearer invalid-token'},
+    )
+
+    assert response.status_code == 401
+    assert response.json()['detail']['error'] == 'invalid_token'
+    assert verifier.tokens == ['invalid-token']
+    assert orchestrator.calls == []
+
+
+def test_authenticated_request_reaches_handler_with_verified_claims(
+    ingress_client: tuple[TestClient, _RecordingVerifier, _RecordingOrchestrator],
+) -> None:
+    client, verifier, orchestrator = ingress_client
+
+    response = client.post(
+        '/v1/run',
+        json=_AGENT_REQUEST,
+        headers={
+            'Authorization': 'Bearer valid-token',
+            'X-Request-ID': _REQUEST_ID,
+        },
+    )
+
+    assert response.status_code == 200
+    assert verifier.tokens == ['valid-token']
+    assert len(orchestrator.calls) == 1
+    request, claims, request_id = orchestrator.calls[0]
+    assert request.agent.value == 'support'
+    assert claims == dict(_PRINCIPAL.claims)
+    assert request_id == _REQUEST_ID
+
+
+def test_healthz_remains_public_and_bypasses_verifier(
+    ingress_client: tuple[TestClient, _RecordingVerifier, _RecordingOrchestrator],
+) -> None:
+    client, verifier, orchestrator = ingress_client
+
+    response = client.get('/healthz')
+
+    assert response.status_code == 200
+    assert response.json() == {'status': 'ok'}
+    assert verifier.tokens == []
+    assert orchestrator.calls == []
+
+
+@pytest.mark.asyncio
+async def test_lifespan_installs_verifier_before_external_resources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    installed_on: list[object] = []
+
+    class _VerifierInstallFailed(RuntimeError):
+        pass
+
+    def fail_install(app: object) -> None:
+        installed_on.append(app)
+        raise _VerifierInstallFailed
+
+    async def unexpected_pool_creation(*args: object, **kwargs: object) -> None:
+        pytest.fail('database initialization ran before verifier installation')
+
+    monkeypatch.setattr(gateway_main, 'install_verifier', fail_install)
+    monkeypatch.setattr(gateway_main.asyncpg, 'create_pool', unexpected_pool_creation)
+
+    with pytest.raises(_VerifierInstallFailed):
+        async with gateway_main.lifespan(gateway_main.app):
+            pytest.fail('lifespan yielded after verifier installation failed')
+
+    assert installed_on == [gateway_main.app]

--- a/services/api-gateway/tests/runtime/test_gateway_ingress.py
+++ b/services/api-gateway/tests/runtime/test_gateway_ingress.py
@@ -1,7 +1,18 @@
 # SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
 # File: services/api-gateway/tests/runtime/test_gateway_ingress.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
 #
-# Active API Gateway ingress tests for ISSUE 009.
+# Description: Verifies AstraDesk behavior for the associated component.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
 from __future__ import annotations
 
 from collections.abc import Iterator

--- a/services/api-gateway/tests/runtime/test_gateway_ingress.py
+++ b/services/api-gateway/tests/runtime/test_gateway_ingress.py
@@ -72,9 +72,7 @@ def ingress_client(
 ) -> Iterator[tuple[TestClient, _RecordingVerifier, _RecordingOrchestrator]]:
     verifier = _RecordingVerifier()
     orchestrator = _RecordingOrchestrator()
-    monkeypatch.setattr(
-        gateway_main.app.state, 'token_verifier', verifier, raising=False
-    )
+    monkeypatch.setattr(gateway_main.app.state, 'token_verifier', verifier, raising=False)
     monkeypatch.setitem(gateway_main.app_state, 'orchestrator', orchestrator)
     client = TestClient(gateway_main.app)
     yield client, verifier, orchestrator

--- a/services/api-gateway/tests/runtime/test_oidc_ingress.py
+++ b/services/api-gateway/tests/runtime/test_oidc_ingress.py
@@ -28,12 +28,12 @@ from astradesk_core.utils.oidc import (
 )
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-ISSUER = "https://issuer.example.test/"
-AUDIENCE = "astradesk-api"
-KID = "test-key-1"
+ISSUER = 'https://issuer.example.test/'
+AUDIENCE = 'astradesk-api'
+KID = 'test-key-1'
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def rsa_keypair() -> tuple[rsa.RSAPrivateKey, rsa.RSAPublicKey]:
     private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     return private, private.public_key()
@@ -45,15 +45,15 @@ def verifier(rsa_keypair) -> TokenVerifier:
     settings = OIDCSettings(
         issuer=ISSUER,
         audience=AUDIENCE,
-        jwks_url="https://unused.test/jwks",
-        algorithms=("RS256",),
+        jwks_url='https://unused.test/jwks',
+        algorithms=('RS256',),
         leeway_seconds=5,
     )
 
     def resolver(token: str):
         header = jwt.get_unverified_header(token)
-        if header.get("kid") != KID:
-            raise AuthError("invalid_token", "unknown kid")
+        if header.get('kid') != KID:
+            raise AuthError('invalid_token', 'unknown kid')
         return public
 
     return TokenVerifier(settings, key_resolver=resolver)
@@ -62,29 +62,29 @@ def verifier(rsa_keypair) -> TokenVerifier:
 def _mint(
     private,
     *,
-    sub="user-1",
+    sub='user-1',
     aud=AUDIENCE,
     iss=ISSUER,
     kid=KID,
     exp_delta=300,
     nbf_delta=None,
-    roles=("operator",),
+    roles=('operator',),
     extra=None,
 ) -> str:
     now = int(time.time())
     payload = {
-        "sub": sub,
-        "aud": aud,
-        "iss": iss,
-        "iat": now,
-        "exp": now + exp_delta,
-        "roles": list(roles),
+        'sub': sub,
+        'aud': aud,
+        'iss': iss,
+        'iat': now,
+        'exp': now + exp_delta,
+        'roles': list(roles),
     }
     if nbf_delta is not None:
-        payload["nbf"] = now + nbf_delta
+        payload['nbf'] = now + nbf_delta
     if extra:
         payload.update(extra)
-    return jwt.encode(payload, private, algorithm="RS256", headers={"kid": kid})
+    return jwt.encode(payload, private, algorithm='RS256', headers={'kid': kid})
 
 
 # --- positive control --------------------------------------------------------
@@ -93,8 +93,8 @@ def _mint(
 def test_valid_token_passes(verifier, rsa_keypair):
     private, _ = rsa_keypair
     principal = verifier.verify(_mint(private))
-    assert principal.subject == "user-1"
-    assert "operator" in principal.roles
+    assert principal.subject == 'user-1'
+    assert 'operator' in principal.roles
 
 
 # --- negative matrix (each must be denied) -----------------------------------
@@ -102,57 +102,57 @@ def test_valid_token_passes(verifier, rsa_keypair):
 
 def test_empty_token_denied(verifier):
     with pytest.raises(AuthError) as e:
-        verifier.verify("")
-    assert e.value.code == "missing_token"
+        verifier.verify('')
+    assert e.value.code == 'missing_token'
 
 
 def test_bad_signature_denied(verifier):
     other = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     with pytest.raises(AuthError) as e:
         verifier.verify(_mint(other))  # signed by a key the resolver won't return
-    assert e.value.code == "invalid_token"
+    assert e.value.code == 'invalid_token'
 
 
 def test_wrong_audience_denied(verifier, rsa_keypair):
     private, _ = rsa_keypair
     with pytest.raises(AuthError) as e:
-        verifier.verify(_mint(private, aud="some-other-api"))
-    assert e.value.code == "invalid_audience"
+        verifier.verify(_mint(private, aud='some-other-api'))
+    assert e.value.code == 'invalid_audience'
 
 
 def test_wrong_issuer_denied(verifier, rsa_keypair):
     private, _ = rsa_keypair
     with pytest.raises(AuthError) as e:
-        verifier.verify(_mint(private, iss="https://evil.example/"))
-    assert e.value.code == "invalid_issuer"
+        verifier.verify(_mint(private, iss='https://evil.example/'))
+    assert e.value.code == 'invalid_issuer'
 
 
 def test_expired_token_denied(verifier, rsa_keypair):
     private, _ = rsa_keypair
     with pytest.raises(AuthError) as e:
         verifier.verify(_mint(private, exp_delta=-60))
-    assert e.value.code == "token_expired"
+    assert e.value.code == 'token_expired'
 
 
 def test_not_yet_valid_token_denied(verifier, rsa_keypair):
     private, _ = rsa_keypair
     with pytest.raises(AuthError) as e:
         verifier.verify(_mint(private, nbf_delta=3600))
-    assert e.value.code == "token_not_yet_valid"
+    assert e.value.code == 'token_not_yet_valid'
 
 
 def test_unknown_kid_denied(verifier, rsa_keypair):
     private, _ = rsa_keypair
     with pytest.raises(AuthError) as e:
-        verifier.verify(_mint(private, kid="rotated-away"))
-    assert e.value.code == "invalid_token"
+        verifier.verify(_mint(private, kid='rotated-away'))
+    assert e.value.code == 'invalid_token'
 
 
 def test_subjectless_token_denied(verifier, rsa_keypair):
     private, _ = rsa_keypair
     with pytest.raises(AuthError) as e:
-        verifier.verify(_mint(private, sub=""))
-    assert e.value.code == "invalid_token"
+        verifier.verify(_mint(private, sub=''))
+    assert e.value.code == 'invalid_token'
 
 
 def test_required_scope_enforced(rsa_keypair):
@@ -160,13 +160,13 @@ def test_required_scope_enforced(rsa_keypair):
     settings = OIDCSettings(
         issuer=ISSUER,
         audience=AUDIENCE,
-        jwks_url="https://unused.test/jwks",
-        required_scopes=("agents:run",),
+        jwks_url='https://unused.test/jwks',
+        required_scopes=('agents:run',),
     )
     v = TokenVerifier(settings, key_resolver=lambda t: public)
     with pytest.raises(AuthError) as e:
-        v.verify(_mint(private, extra={"scope": "agents:read"}))
-    assert e.value.code == "insufficient_scope"
+        v.verify(_mint(private, extra={'scope': 'agents:read'}))
+    assert e.value.code == 'insufficient_scope'
 
 
 def test_keycloak_realm_access_roles_supported(rsa_keypair):
@@ -174,34 +174,34 @@ def test_keycloak_realm_access_roles_supported(rsa_keypair):
     settings = OIDCSettings(
         issuer=ISSUER,
         audience=AUDIENCE,
-        jwks_url="https://unused.test/jwks",
-        roles_claim="realm_access.roles",
+        jwks_url='https://unused.test/jwks',
+        roles_claim='realm_access.roles',
     )
     verifier = TokenVerifier(settings, key_resolver=lambda _token: public)
-    token = _mint(private, extra={"realm_access": {"roles": ["sre", "support.agent"]}})
+    token = _mint(private, extra={'realm_access': {'roles': ['sre', 'support.agent']}})
     principal = verifier.verify(token)
-    assert principal.roles == ("sre", "support.agent")
+    assert principal.roles == ('sre', 'support.agent')
 
 
 # --- startup fail-closed (INV-OIDC-1 / INV-OIDC-3) ---------------------------
 
 
 def test_missing_prod_config_aborts(monkeypatch):
-    for var in ("OIDC_ISSUER", "OIDC_AUDIENCE", "OIDC_JWKS_URL"):
+    for var in ('OIDC_ISSUER', 'OIDC_AUDIENCE', 'OIDC_JWKS_URL'):
         monkeypatch.delenv(var, raising=False)
-    monkeypatch.setenv("AUTH_MODE", "production")
+    monkeypatch.setenv('AUTH_MODE', 'production')
     with pytest.raises(AuthConfigError):
         build_verifier_from_env()
 
 
 def test_local_dev_refused_on_deployed_tier(monkeypatch):
-    monkeypatch.setenv("AUTH_MODE", "local-dev")
-    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv('AUTH_MODE', 'local-dev')
+    monkeypatch.setenv('ENVIRONMENT', 'production')
     with pytest.raises(AuthConfigError):
         build_verifier_from_env()
 
 
 def test_unknown_auth_mode_aborts(monkeypatch):
-    monkeypatch.setenv("AUTH_MODE", "anything-goes")
+    monkeypatch.setenv('AUTH_MODE', 'anything-goes')
     with pytest.raises(AuthConfigError):
         build_verifier_from_env()

--- a/services/api-gateway/tests/runtime/test_oidc_ingress.py
+++ b/services/api-gateway/tests/runtime/test_oidc_ingress.py
@@ -1,11 +1,18 @@
 # SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
 # File: services/api-gateway/tests/runtime/test_oidc_ingress.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
 #
-# Negative-test matrix for the OIDC ingress verifier (ISSUE 009).
+# Description: Verifies AstraDesk behavior for the associated component.
 #
-# Proves the identity control fails closed. No network: the JWKS resolver is
-# injected with a deterministic public key. Tokens are minted with a local RSA
-# key so we can exercise each rejection path precisely.
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
 from __future__ import annotations
 
 import time

--- a/services/api-gateway/tests/runtime/test_oidc_ingress.py
+++ b/services/api-gateway/tests/runtime/test_oidc_ingress.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# File: services/api-gateway/tests/runtime/test_oidc_ingress.py
+#
+# Negative-test matrix for the OIDC ingress verifier (ISSUE 009).
+#
+# Proves the identity control fails closed. No network: the JWKS resolver is
+# injected with a deterministic public key. Tokens are minted with a local RSA
+# key so we can exercise each rejection path precisely.
+from __future__ import annotations
+
+import time
+
+import jwt
+import pytest
+from astradesk_core.utils.oidc import (
+    AuthConfigError,
+    AuthError,
+    OIDCSettings,
+    TokenVerifier,
+    build_verifier_from_env,
+)
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+ISSUER = "https://issuer.example.test/"
+AUDIENCE = "astradesk-api"
+KID = "test-key-1"
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair() -> tuple[rsa.RSAPrivateKey, rsa.RSAPublicKey]:
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private, private.public_key()
+
+
+@pytest.fixture
+def verifier(rsa_keypair) -> TokenVerifier:
+    _, public = rsa_keypair
+    settings = OIDCSettings(
+        issuer=ISSUER,
+        audience=AUDIENCE,
+        jwks_url="https://unused.test/jwks",
+        algorithms=("RS256",),
+        leeway_seconds=5,
+    )
+
+    def resolver(token: str):
+        header = jwt.get_unverified_header(token)
+        if header.get("kid") != KID:
+            raise AuthError("invalid_token", "unknown kid")
+        return public
+
+    return TokenVerifier(settings, key_resolver=resolver)
+
+
+def _mint(
+    private,
+    *,
+    sub="user-1",
+    aud=AUDIENCE,
+    iss=ISSUER,
+    kid=KID,
+    exp_delta=300,
+    nbf_delta=None,
+    roles=("operator",),
+    extra=None,
+) -> str:
+    now = int(time.time())
+    payload = {
+        "sub": sub,
+        "aud": aud,
+        "iss": iss,
+        "iat": now,
+        "exp": now + exp_delta,
+        "roles": list(roles),
+    }
+    if nbf_delta is not None:
+        payload["nbf"] = now + nbf_delta
+    if extra:
+        payload.update(extra)
+    return jwt.encode(payload, private, algorithm="RS256", headers={"kid": kid})
+
+
+# --- positive control --------------------------------------------------------
+
+
+def test_valid_token_passes(verifier, rsa_keypair):
+    private, _ = rsa_keypair
+    principal = verifier.verify(_mint(private))
+    assert principal.subject == "user-1"
+    assert "operator" in principal.roles
+
+
+# --- negative matrix (each must be denied) -----------------------------------
+
+
+def test_empty_token_denied(verifier):
+    with pytest.raises(AuthError) as e:
+        verifier.verify("")
+    assert e.value.code == "missing_token"
+
+
+def test_bad_signature_denied(verifier):
+    other = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    with pytest.raises(AuthError) as e:
+        verifier.verify(_mint(other))  # signed by a key the resolver won't return
+    assert e.value.code == "invalid_token"
+
+
+def test_wrong_audience_denied(verifier, rsa_keypair):
+    private, _ = rsa_keypair
+    with pytest.raises(AuthError) as e:
+        verifier.verify(_mint(private, aud="some-other-api"))
+    assert e.value.code == "invalid_audience"
+
+
+def test_wrong_issuer_denied(verifier, rsa_keypair):
+    private, _ = rsa_keypair
+    with pytest.raises(AuthError) as e:
+        verifier.verify(_mint(private, iss="https://evil.example/"))
+    assert e.value.code == "invalid_issuer"
+
+
+def test_expired_token_denied(verifier, rsa_keypair):
+    private, _ = rsa_keypair
+    with pytest.raises(AuthError) as e:
+        verifier.verify(_mint(private, exp_delta=-60))
+    assert e.value.code == "token_expired"
+
+
+def test_not_yet_valid_token_denied(verifier, rsa_keypair):
+    private, _ = rsa_keypair
+    with pytest.raises(AuthError) as e:
+        verifier.verify(_mint(private, nbf_delta=3600))
+    assert e.value.code == "token_not_yet_valid"
+
+
+def test_unknown_kid_denied(verifier, rsa_keypair):
+    private, _ = rsa_keypair
+    with pytest.raises(AuthError) as e:
+        verifier.verify(_mint(private, kid="rotated-away"))
+    assert e.value.code == "invalid_token"
+
+
+def test_subjectless_token_denied(verifier, rsa_keypair):
+    private, _ = rsa_keypair
+    with pytest.raises(AuthError) as e:
+        verifier.verify(_mint(private, sub=""))
+    assert e.value.code == "invalid_token"
+
+
+def test_required_scope_enforced(rsa_keypair):
+    private, public = rsa_keypair
+    settings = OIDCSettings(
+        issuer=ISSUER,
+        audience=AUDIENCE,
+        jwks_url="https://unused.test/jwks",
+        required_scopes=("agents:run",),
+    )
+    v = TokenVerifier(settings, key_resolver=lambda t: public)
+    with pytest.raises(AuthError) as e:
+        v.verify(_mint(private, extra={"scope": "agents:read"}))
+    assert e.value.code == "insufficient_scope"
+
+
+def test_keycloak_realm_access_roles_supported(rsa_keypair):
+    private, public = rsa_keypair
+    settings = OIDCSettings(
+        issuer=ISSUER,
+        audience=AUDIENCE,
+        jwks_url="https://unused.test/jwks",
+        roles_claim="realm_access.roles",
+    )
+    verifier = TokenVerifier(settings, key_resolver=lambda _token: public)
+    token = _mint(private, extra={"realm_access": {"roles": ["sre", "support.agent"]}})
+    principal = verifier.verify(token)
+    assert principal.roles == ("sre", "support.agent")
+
+
+# --- startup fail-closed (INV-OIDC-1 / INV-OIDC-3) ---------------------------
+
+
+def test_missing_prod_config_aborts(monkeypatch):
+    for var in ("OIDC_ISSUER", "OIDC_AUDIENCE", "OIDC_JWKS_URL"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("AUTH_MODE", "production")
+    with pytest.raises(AuthConfigError):
+        build_verifier_from_env()
+
+
+def test_local_dev_refused_on_deployed_tier(monkeypatch):
+    monkeypatch.setenv("AUTH_MODE", "local-dev")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    with pytest.raises(AuthConfigError):
+        build_verifier_from_env()
+
+
+def test_unknown_auth_mode_aborts(monkeypatch):
+    monkeypatch.setenv("AUTH_MODE", "anything-goes")
+    with pytest.raises(AuthConfigError):
+        build_verifier_from_env()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,8 +17,16 @@ from fastapi.testclient import TestClient
 from gateway.main import app
 
 
-def test_healthz_ok():
+def test_healthz_ok(monkeypatch):
+    monkeypatch.setenv('AUTH_MODE', 'local-dev')
+    monkeypatch.setenv('ENVIRONMENT', 'dev')
+    monkeypatch.setenv('ASTRADESK_DEV_JWT_SECRET', 'test-only-local-dev-secret')
+    monkeypatch.delenv('OIDC_ISSUER', raising=False)
+    monkeypatch.delenv('OIDC_AUDIENCE', raising=False)
+    monkeypatch.delenv('OIDC_JWKS_URL', raising=False)
+
     with TestClient(app) as c:
         r = c.get('/healthz')
-        assert r.status_code == 200
-        assert r.json()['status'] == 'ok'
+
+    assert r.status_code == 200
+    assert r.json()['status'] == 'ok'

--- a/uv.lock
+++ b/uv.lock
@@ -404,6 +404,9 @@ requires-dist = [
 name = "astradesk-core"
 version = "0.3.0"
 source = { editable = "core" }
+dependencies = [
+    { name = "pyjwt", extra = ["crypto"] },
+]
 
 [package.optional-dependencies]
 dev = [
@@ -420,6 +423,7 @@ dev = [
 requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11,<1.12" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7,<3.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
@@ -2873,6 +2877,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements ISSUE 009: wires OIDC/JWKS verification into the active API Gateway ingress path.

This PR moves AstraDesk Gateway authentication from the previous development-secret HS256 fallback to a fail-closed OIDC/JWKS verifier for production, while keeping an explicit `AUTH_MODE=local-dev` path for local development and tests.

## What changed

### OIDC verifier foundation

* Added `astradesk_core.utils.oidc`.
* Added production OIDC/JWKS token verification.
* Added explicit `local-dev` verifier mode.
* Production startup now fails closed if required OIDC config is missing:

  * `OIDC_ISSUER`
  * `OIDC_AUDIENCE`
  * `OIDC_JWKS_URL`
* Added JWKS key cache with refresh on `kid` miss.
* Added support for configurable role claims, including Keycloak-style dotted paths such as `realm_access.roles`.

### API Gateway ingress

* Added `gateway.auth_dependency`.
* Installs the verifier during Gateway lifespan startup.
* Protects active `POST /v1/run` with `Depends(require_authenticated)`.
* Removes the legacy HS256 hardcoded development-secret fallback from active Gateway ingress.
* Keeps `/healthz` public.
* Passes verified principal claims into the existing orchestrator path.

### Tests

Added negative and boundary tests for:

* missing token
* malformed bearer header
* invalid token
* bad signature
* wrong audience
* wrong issuer
* expired token
* future `nbf`
* unknown `kid`
* missing subject
* required scope enforcement
* local-dev refusal on deployed tiers
* Keycloak `realm_access.roles`
* active Gateway route rejecting unauthenticated requests before handler/orchestrator execution
* `/healthz` remaining public after real lifespan startup

### Roadmap / tracker

* Adds v0.3.1 Safety Core roadmap contracts.
* Adds tracker seed script for v0.3.1 hardening issues.

## Verification

Executed locally:

```text
uv sync --all-extras --frozen
```

```text
uv run ruff check tests/test_api.py core/src services/api-gateway/src services/api-gateway/tests
All checks passed!
```

```text
uv run pytest -q tests/test_api.py
1 passed
```

```text
uv run pytest -q services/api-gateway/tests/runtime/test_gateway_ingress.py services/api-gateway/tests/runtime/test_oidc_ingress.py services/api-gateway/tests/runtime/test_auth_dependency.py
23 passed
```

```text
uv run pytest -q services/api-gateway/tests
229 passed
```

```text
make test
11 passed, 2 warnings
```

Known warning baseline:

* `PytestCollectionWarning` for `TestScenario` and `TestResult` classes with `__init__` constructors.

## Notes

Full import-following mypy for the broader API Gateway still has the existing OpenTelemetry baseline:

```text
Module "opentelemetry" has no attribute "trace" [attr-defined]
```

This PR does not address that unrelated baseline.

## Status

ISSUE 009 is ready for review.

Merge target: `develop`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OIDC-based authentication for API requests, including stricter token validation and clearer unauthorized responses.
  * Introduced roadmap guidance for upcoming hardening, reliability, and deployment improvements.

* **Bug Fixes**
  * Expanded CI to run on both `main` and `develop` branches.
  * Improved repository tracking so key roadmap and audit files remain included.

* **Documentation**
  * Added and updated roadmap documents and milestone planning details.

* **Tests**
  * Added runtime coverage for authentication, ingress behavior, and token verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->