### PR TITLE
fix(ci): restore Python coverage path for Sonar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           uv run mypy .
 
       - name: Run Python Tests with Coverage
-        run: uv run pytest -q
+        run: uv run pytest -q --cov-report=xml:coverage.xml
 
       - name: Build Docker Image (Python)
         run: docker build -t astradesk:ci-python -f Dockerfile .
@@ -167,6 +167,11 @@ jobs:
 
       - name: Verify downloaded reports
         run: ls -R coverage-reports
+
+      - name: Place Python coverage report for Sonar
+        run: |
+          cp coverage-reports/python-coverage/coverage.xml coverage.xml
+          test -s coverage.xml
 
       - name: Run SonarQube Scan
         env:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -28,7 +28,7 @@ sonar.tests=tests,services/ticket-adapter-java/src/test/java,services/admin-port
 sonar.test.inclusions=**/*_test.py,**/test_*.py,**/*Test.java,**/*.test.ts,**/*.test.tsx
 
 # Language-specific settings
-sonar.python.version=3.14
+sonar.python.version=3.13
 sonar.java.source=25
 sonar.java.binaries=services/ticket-adapter-java/build/classes/java/main
 sonar.typescript.tsconfigPath=services/admin-portal/tsconfig.json


### PR DESCRIPTION
## Summary

Fixes Python coverage reporting for SonarCloud.

Python tests already generate `coverage.xml`, but the Sonar job downloaded the `python-coverage` artifact into `coverage-reports/python-coverage/coverage.xml` while `sonar-project.properties` expected `coverage.xml` at repository root.

This caused SonarCloud to report `0.0% Coverage on New Code` despite coverage being generated.

## Changes

- Keep Python coverage output as `coverage.xml`.
- After downloading coverage artifacts, copy `coverage-reports/python-coverage/coverage.xml` back to repository root.
- Verify `coverage.xml` is non-empty before Sonar runs.
- Align `sonar.python.version` with the project baseline: Python 3.13.

## Verification

```text
uv run pytest -q --cov-report=xml:coverage.xml
264 passed, 2 warnings
Coverage XML written to file coverage.xml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the CI process to generate and verify a Python coverage report so analysis tools can reliably use test coverage data.
  * Adjusted the configured Python version for code analysis to match the supported runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->