### PR TITLE
Issue/016 RBAC invariant

### DIFF
--- a/services/api-gateway/src/agents/base.py
+++ b/services/api-gateway/src/agents/base.py
@@ -41,6 +41,7 @@ import networkx as nx  # For Intent Graph (DiGraph with nodes/edges)
 from model_gateway.llm_planner import LLMPlanner
 from opentelemetry import trace  # AstraOps/OTel tracing
 from pydantic import BaseModel
+from runtime.authz import approval_from_mapping
 from runtime.memory import Memory
 from runtime.models import ToolCall
 from runtime.planner import KeywordPlanner
@@ -263,6 +264,10 @@ class BaseAgent(ABC):
                 # OPA governance with flexible wrapper
                 raw_claims = context.get('claims')
                 claims = raw_claims if isinstance(raw_claims, dict) else {}
+                # Normalized roles + approval id for the RBAC choke point
+                # (same as the LLM path; write/execute deny without approval).
+                roles = context.get('roles', ())
+                approval_id = approval_from_mapping(context)
                 opa_payload = {'action': step.name, 'claims': claims}
                 try:
                     await _authorize(self.opa_policy, 'tools.invoke', claims, opa_payload)
@@ -276,7 +281,13 @@ class BaseAgent(ABC):
                 # Execute with timeout
                 try:
                     result = await asyncio.wait_for(
-                        self.tools.execute(step.name, claims=claims, **step.arguments),
+                        self.tools.execute(
+                            step.name,
+                            roles=roles,
+                            approval_id=approval_id,
+                            claims=claims,
+                            **step.arguments,
+                        ),
                         timeout=TOOL_TIMEOUT_SEC,
                     )
                 except TimeoutError:

--- a/services/api-gateway/src/agents/billing.py
+++ b/services/api-gateway/src/agents/billing.py
@@ -38,6 +38,7 @@ from typing import Any
 import networkx as nx
 from model_gateway.llm_planner import LLMPlanner
 from opentelemetry import trace
+from runtime.authz import approval_from_mapping
 from runtime.memory import Memory
 from runtime.models import ToolCall
 from runtime.planner import KeywordPlanner
@@ -280,6 +281,8 @@ class BillingAgent(BaseAgent):
         """Executes the billing agent workflow with specialized planning and finalization."""
         context = context or {}
         claims = context.get('claims', {})
+        roles = context.get('roles', ())  # normalized roles for the RBAC choke point
+        approval_id = approval_from_mapping(context)  # change-record for write/execute
         tenant = claims.get('tenant', 'unknown')
 
         with self.tracer.start_as_current_span('billing.run') as span:
@@ -335,7 +338,13 @@ class BillingAgent(BaseAgent):
 
                 try:
                     result = await asyncio.wait_for(
-                        self.tools.execute(step.name, claims=claims, **step.arguments),
+                        self.tools.execute(
+                            step.name,
+                            roles=roles,
+                            approval_id=approval_id,
+                            claims=claims,
+                            **step.arguments,
+                        ),
                         timeout=TOOL_TIMEOUT_SEC,
                     )
                 except TimeoutError:

--- a/services/api-gateway/src/agents/ops.py
+++ b/services/api-gateway/src/agents/ops.py
@@ -38,6 +38,7 @@ from typing import Any
 import networkx as nx
 from model_gateway.llm_planner import LLMPlanner
 from opentelemetry import trace
+from runtime.authz import approval_from_mapping
 from runtime.memory import Memory
 from runtime.models import ToolCall
 from runtime.planner import KeywordPlanner
@@ -267,6 +268,8 @@ class OpsAgent(BaseAgent):
         """Executes the ops agent workflow with specialized planning and finalization."""
         context = context or {}
         claims = context.get('claims', {})
+        roles = context.get('roles', ())  # normalized roles for the RBAC choke point
+        approval_id = approval_from_mapping(context)  # change-record for write/execute
         user_id = claims.get('user_id', 'unknown')
 
         with self.tracer.start_as_current_span('ops.run') as span:
@@ -314,7 +317,13 @@ class OpsAgent(BaseAgent):
 
                 try:
                     result = await asyncio.wait_for(
-                        self.tools.execute(step.name, claims=claims, **step.arguments),
+                        self.tools.execute(
+                            step.name,
+                            roles=roles,
+                            approval_id=approval_id,
+                            claims=claims,
+                            **step.arguments,
+                        ),
                         timeout=TOOL_TIMEOUT_SEC,
                     )
                 except TimeoutError:

--- a/services/api-gateway/src/agents/support.py
+++ b/services/api-gateway/src/agents/support.py
@@ -38,6 +38,7 @@ from typing import Any
 import networkx as nx
 from model_gateway.llm_planner import LLMPlanner
 from opentelemetry import trace
+from runtime.authz import approval_from_mapping
 from runtime.memory import Memory
 from runtime.models import ToolCall
 from runtime.planner import KeywordPlanner
@@ -275,6 +276,8 @@ class SupportAgent(BaseAgent):
         """Executes the support agent workflow with specialized planning and finalization."""
         context = context or {}
         claims = context.get('claims', {})
+        roles = context.get('roles', ())  # normalized roles for the RBAC choke point
+        approval_id = approval_from_mapping(context)  # change-record for write/execute
         user_id = claims.get('user_id', 'unknown')
 
         with self.tracer.start_as_current_span('support.run') as span:
@@ -322,7 +325,13 @@ class SupportAgent(BaseAgent):
 
                 try:
                     result = await asyncio.wait_for(
-                        self.tools.execute(step.name, claims=claims, **step.arguments),
+                        self.tools.execute(
+                            step.name,
+                            roles=roles,
+                            approval_id=approval_id,
+                            claims=claims,
+                            **step.arguments,
+                        ),
                         timeout=TOOL_TIMEOUT_SEC,
                     )
                 except TimeoutError:

--- a/services/api-gateway/src/gateway/main.py
+++ b/services/api-gateway/src/gateway/main.py
@@ -47,6 +47,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
 from model_gateway.llm_planner import LLMPlanner
 from model_gateway.router import provider_router
 from opa_client.opa import OpaClient
+from runtime.authz import SideEffect, enforce_registration_invariants
 from runtime.memory import Memory
 from runtime.models import AgentRequest, AgentResponse
 from runtime.planner import KeywordPlanner
@@ -108,18 +109,39 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # --- Initialize core components ---
     tool_registry = ToolRegistry()
-    # Register built-in tools
+    # Register built-in tools with mandatory RBAC metadata (ISSUE 016).
+    # side_effect + allowed_roles are the source of truth for the choke point;
+    # the OIDC layer normalizes identity/roles, RBAC authorizes from those roles.
     await tool_registry.register(
-        'get_metrics', metrics.get_metrics, description='Get service performance metrics.'
+        'get_metrics',
+        metrics.get_metrics,
+        side_effect=SideEffect.READ,
+        description='Get service performance metrics.',
     )
     await tool_registry.register(
-        'restart_service', ops_actions.restart_service, description='Restart a service deployment.'
+        'restart_service',
+        ops_actions.restart_service,
+        side_effect=SideEffect.EXECUTE,
+        allowed_roles={'sre'},
+        description='Restart a service deployment.',
     )
     await tool_registry.register(
-        'create_ticket', tickets_proxy.create_ticket, description='Create a support ticket.'
+        'create_ticket',
+        tickets_proxy.create_ticket,
+        side_effect=SideEffect.WRITE,
+        allowed_roles={'it.support', 'sre'},
+        description='Create a support ticket.',
     )
-    # Discover and load tools from external domain packs
+    # Discover and load tools from external domain packs.
     load_domain_packs(tool_registry)
+
+    # Boot-time RBAC invariant: abort startup if any registered tool lacks
+    # side_effect metadata or any side-effecting tool lacks allowed_roles
+    # (fail-closed; catch at boot, not at the first unauthorized call).
+    enforce_registration_invariants(
+        (info.name, info.side_effect, info.allowed_roles, info.requires_approval)
+        for info in tool_registry.infos()
+    )
 
     # llm_planner = LLMPlanner(opa_client=opa_client)
     # rag = RAG(pg_pool=pg_pool, llm_planner=llm_planner)
@@ -266,7 +288,12 @@ async def execute_agent(
     request_id = request.headers.get('X-Request-ID', str(uuid.uuid4()))
 
     try:
-        response = await orchestrator.run(agent_request, dict(principal.claims), request_id)
+        response = await orchestrator.run(
+            agent_request,
+            dict(principal.claims),
+            request_id,
+            roles=tuple(principal.roles),
+        )
         return response
     except AgentNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/services/api-gateway/src/gateway/orchestrator.py
+++ b/services/api-gateway/src/gateway/orchestrator.py
@@ -32,6 +32,7 @@ from model_gateway.guardrails import PlanModel
 from model_gateway.llm_planner import LLMPlanner
 from opa_client.opa import OpaClient  # Governance
 from opentelemetry import trace  # AstraOps/OTel
+from runtime.authz import approval_from_mapping
 from runtime.memory import Memory
 from runtime.models import AgentRequest, AgentResponse, ToolCall
 from runtime.registry import ToolRegistry
@@ -95,7 +96,11 @@ class AgentOrchestrator:
         self.tracer = trace.get_tracer(__name__)
 
     async def run(
-        self, req: AgentRequest, claims: dict[str, Any], request_id: str
+        self,
+        req: AgentRequest,
+        claims: dict[str, Any],
+        request_id: str,
+        roles: tuple[str, ...] = (),
     ) -> AgentResponse:
         """Main execution entrypoint with LLM → Keyword → Fallback strategy.
 
@@ -103,6 +108,10 @@ class AgentOrchestrator:
             req: Incoming agent request.
             claims: JWT claims from auth layer.
             request_id: Unique trace ID.
+            roles: Normalized principal roles from the OIDC layer. These — not the
+                raw claims — feed the RBAC choke point, and they are propagated
+                identically to the LLM-planned and keyword-fallback paths
+                (``INV-DUAL-PATH``).
 
         Returns:
             AgentResponse with output and invoked tools.
@@ -116,7 +125,12 @@ class AgentOrchestrator:
             span.set_attribute('agent', req.agent.value)
             span.set_attribute('input_preview', req.input[:100])
 
-            context = {**req.meta, 'claims': claims, 'request_id': request_id}
+            context = {
+                **req.meta,
+                'claims': claims,
+                'roles': tuple(roles),
+                'request_id': request_id,
+            }
             memory = Memory(self.pg_pool, self.redis)
 
             # Try LLM path first
@@ -178,10 +192,18 @@ class AgentOrchestrator:
             if not decision.get('result', False):
                 raise PolicyViolationError(step.name)
 
-            # Execute with timeout
+            # Execute with timeout (RBAC enforced inside tools.execute from
+            # normalized roles + approval id — identical to the keyword-fallback
+            # path). write/execute tools deny without an approval/change record.
             try:
                 result = await asyncio.wait_for(
-                    self.tools.execute(step.name, claims=context['claims'], **step.args),
+                    self.tools.execute(
+                        step.name,
+                        roles=context.get('roles', ()),
+                        approval_id=approval_from_mapping(context),
+                        claims=context['claims'],
+                        **step.args,
+                    ),
                     timeout=30.0,
                 )
             except TimeoutError:

--- a/services/api-gateway/src/runtime/authz.py
+++ b/services/api-gateway/src/runtime/authz.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/src/runtime/authz.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Implements AstraDesk functionality for services/api-gateway/src/runtime/authz.py.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""RBAC authorization choke point for tool execution (ISSUE 016).
+
+This module is the *single* place where a tool invocation is authorized. Both the
+LLM-planned path and the deterministic keyword-fallback path funnel every tool
+call through :class:`runtime.registry.ToolRegistry.execute`, which delegates the
+authorization decision to :func:`authorize_tool` here. Authority is therefore a
+property of the invocation, not of the code path that produced it
+(``INV-DUAL-PATH``).
+
+Canonical input
+---------------
+Authorization consumes **normalized roles** only. The OIDC layer
+(:mod:`astradesk_core.utils.oidc`) is responsible for turning IdP-specific claim
+shapes (``roles``, ``realm_access.roles``, ...) into ``Principal.roles`` via the
+``OIDC_ROLES_CLAIM`` configuration. Nothing in this module inspects raw
+IdP-specific claims; the only claim-aware helper is :func:`roles_from_claims`, a
+thin compatibility adapter that delegates to the existing normalized role helper
+and never hardcodes a provider shape.
+
+Fail-closed (``INV-FAIL-CLOSED``)
+---------------------------------
+- Missing ``side_effect`` metadata -> deny (``RBAC_METADATA_MISSING``).
+- ``write``/``execute`` tool with no ``allowed_roles`` -> deny
+  (``RBAC_ROLES_NOT_CONFIGURED``); also rejected at registration time so the
+  failure surfaces at boot rather than at call time.
+- Principal roles do not intersect ``allowed_roles`` -> deny (``RBAC_DENIED``).
+- ``write``/``execute`` invoked without an approval/change record -> deny
+  (``APPROVAL_REQUIRED``). This is a hard gate (``INV-RBAC-4``): a matching role
+  alone is never sufficient for a side-effecting tool. The approval id is read
+  from the conservative fields :data:`APPROVAL_FIELDS` in the invocation arguments
+  or execution context — no public API contract change.
+
+Denial responses carry a stable reason code and the required role names only.
+They never echo the raw token, secrets, credentials, or raw claims.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
+__all__ = [
+    'APPROVAL_FIELDS',
+    'AuthorizationError',
+    'RbacDenied',
+    'RbacReason',
+    'RegistryInvariantError',
+    'SideEffect',
+    'approval_from_mapping',
+    'approval_required_for',
+    'authorize_tool',
+    'coerce_side_effect',
+    'enforce_registration_invariants',
+    'normalize_roles',
+    'roles_from_claims',
+    'validate_tool_metadata',
+]
+
+#: Conservative field names accepted as an approval/change-record id, read from
+#: the tool invocation arguments or the execution context (ISSUE 016, INV-RBAC-4).
+APPROVAL_FIELDS: tuple[str, ...] = ('approval_id', 'change_record', 'change_record_id')
+
+
+class SideEffect(str, Enum):
+    """Declared side-effect class of a tool.
+
+    ``read`` tools observe state and may run without a role restriction. ``write``
+    and ``execute`` tools mutate state or trigger actions and therefore require an
+    explicit, non-empty ``allowed_roles`` set.
+    """
+
+    READ = 'read'
+    WRITE = 'write'
+    EXECUTE = 'execute'
+
+
+#: Side-effect classes that require explicit ``allowed_roles`` and stricter gating.
+SIDE_EFFECTING: frozenset[SideEffect] = frozenset({SideEffect.WRITE, SideEffect.EXECUTE})
+
+
+class RbacReason(str, Enum):
+    """Stable, audit-friendly denial reason codes (non-leaking)."""
+
+    METADATA_MISSING = 'RBAC_METADATA_MISSING'
+    ROLES_NOT_CONFIGURED = 'RBAC_ROLES_NOT_CONFIGURED'
+    ROLE_DENIED = 'RBAC_DENIED'
+    APPROVAL_REQUIRED = 'APPROVAL_REQUIRED'
+
+
+class AuthorizationError(PermissionError):
+    """Base authorization failure with a stable public exception type."""
+
+
+class RbacDenied(AuthorizationError):
+    """Raised when the RBAC choke point denies a tool invocation.
+
+    The message and attributes expose only the tool name, a stable reason code,
+    and the required role names (policy configuration, not secrets). They never
+    contain the raw token, credentials, or raw claims.
+    """
+
+    def __init__(
+        self,
+        reason: RbacReason,
+        tool: str,
+        *,
+        needed_roles: Iterable[str] = (),
+    ) -> None:
+        self.reason = reason
+        self.tool = tool
+        self.needed_roles: tuple[str, ...] = tuple(sorted({str(r) for r in needed_roles}))
+        message = f"Access denied for tool '{tool}' [{reason.value}]"
+        if self.needed_roles:
+            message += f'; requires any of {list(self.needed_roles)}'
+        super().__init__(message)
+
+
+class RegistryInvariantError(RuntimeError):
+    """Raised at startup when a registered tool violates the RBAC metadata invariant.
+
+    Surfacing this aborts process start (fail-closed): a side-effecting tool that
+    reaches the registry without role metadata must be caught at boot, not at the
+    first unauthorized call.
+    """
+
+
+def coerce_side_effect(value: SideEffect | str | None) -> SideEffect:
+    """Coerce a registration input into a :class:`SideEffect`.
+
+    Raises:
+        ValueError: if ``value`` is missing (``None``) or is not one of
+            ``read``/``write``/``execute``. Missing metadata is never silently
+            treated as safe.
+    """
+    if value is None:
+        raise ValueError("side_effect is required: declare one of 'read', 'write', 'execute'.")
+    if isinstance(value, SideEffect):
+        return value
+    try:
+        return SideEffect(str(value).strip().lower())
+    except ValueError as exc:
+        raise ValueError(
+            f'invalid side_effect {value!r}; expected one of read/write/execute.'
+        ) from exc
+
+
+def normalize_roles(roles: Iterable[str] | None) -> frozenset[str]:
+    """Return a case-folded role set from an already-normalized roles iterable."""
+    if not roles:
+        return frozenset()
+    return frozenset(r.casefold() for r in roles if r)
+
+
+def roles_from_claims(claims: Mapping[str, Any] | None) -> frozenset[str]:
+    """Compatibility adapter: derive normalized roles from verified claims.
+
+    Used only when an explicit normalized roles list is not supplied to the choke
+    point. It delegates to the existing normalized role helper
+    (:func:`runtime.policy.get_roles`) and never hardcodes a provider-specific
+    claim shape. RBAC logic proper (:func:`authorize_tool`) operates on the
+    resulting role set, not on the claims.
+    """
+    if not claims:
+        return frozenset()
+    # Imported lazily to keep the authorization core free of policy-store imports.
+    from runtime.policy import get_roles
+
+    return normalize_roles(get_roles(dict(claims)))
+
+
+def validate_tool_metadata(
+    tool: str,
+    side_effect: SideEffect,
+    allowed_roles: Iterable[str],
+) -> None:
+    """Registration-time invariant: a side-effecting tool must declare roles.
+
+    Raises:
+        ValueError: if a ``write``/``execute`` tool has an empty ``allowed_roles``.
+    """
+    if side_effect in SIDE_EFFECTING and not set(allowed_roles):
+        raise ValueError(
+            f"tool '{tool}' is side-effecting ({side_effect.value}) and must "
+            'declare a non-empty allowed_roles set.'
+        )
+
+
+def approval_required_for(side_effect: SideEffect | None, requires_approval: bool) -> bool:
+    """The effective approval rule for ISSUE 016 (``INV-RBAC-4``).
+
+    A ``write``/``execute`` invocation *always* requires an approval/change record,
+    independent of the per-tool ``requires_approval`` flag. The flag may additionally
+    force approval on a ``read`` tool, but it can never relax a side-effecting one.
+    """
+    return side_effect in SIDE_EFFECTING or bool(requires_approval)
+
+
+def approval_from_mapping(source: Mapping[str, Any] | None) -> str | None:
+    """Extract an approval/change-record id from invocation args or context.
+
+    Accepts the conservative field names :data:`APPROVAL_FIELDS`
+    (``approval_id`` / ``change_record`` / ``change_record_id``). Returns the first
+    present, non-empty value, or ``None``. This reads only well-known scalar fields;
+    it never inspects IdP-specific claim shapes.
+    """
+    if not source:
+        return None
+    for field_name in APPROVAL_FIELDS:
+        value = source.get(field_name)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return None
+
+
+def authorize_tool(
+    *,
+    tool: str,
+    side_effect: SideEffect | None,
+    allowed_roles: Iterable[str],
+    roles: Iterable[str],
+    requires_approval: bool = False,
+    approval_id: str | None = None,
+) -> None:
+    """Authorize a single tool invocation from normalized roles. Fail-closed.
+
+    Enforcement order (each step denies before the tool runs):
+
+    1. Missing ``side_effect`` metadata -> ``RBAC_METADATA_MISSING``.
+    2. ``write``/``execute`` without configured roles -> ``RBAC_ROLES_NOT_CONFIGURED``.
+    3. Principal roles do not satisfy ``allowed_roles`` -> ``RBAC_DENIED``.
+    4. ``write``/``execute`` (``INV-RBAC-4``) without an approval/change record, or
+       any tool flagged ``requires_approval`` -> ``APPROVAL_REQUIRED``. A matching
+       role alone is therefore never sufficient for a side-effecting tool.
+
+    Args:
+        tool: Tool name (for the denial reason; not a secret).
+        side_effect: Declared side-effect class, or ``None`` if metadata is absent.
+        allowed_roles: Roles permitted to invoke the tool (policy configuration).
+        roles: The principal's normalized roles.
+        requires_approval: Per-tool flag; may force approval on a ``read`` tool but
+            cannot relax the side-effecting rule.
+        approval_id: The approval/change record id, if supplied by the caller.
+
+    Raises:
+        RbacDenied: with a stable :class:`RbacReason` whenever the invocation is
+            not authorized. The underlying tool function must not run.
+    """
+    if side_effect is None:
+        raise RbacDenied(RbacReason.METADATA_MISSING, tool)
+
+    allowed = normalize_roles(allowed_roles)
+    principal_roles = normalize_roles(roles)
+
+    if side_effect in SIDE_EFFECTING and not allowed:
+        raise RbacDenied(RbacReason.ROLES_NOT_CONFIGURED, tool)
+
+    if allowed and not (principal_roles & allowed):
+        raise RbacDenied(RbacReason.ROLE_DENIED, tool, needed_roles=allowed)
+
+    if approval_required_for(side_effect, requires_approval) and not (
+        approval_id and str(approval_id).strip()
+    ):
+        raise RbacDenied(RbacReason.APPROVAL_REQUIRED, tool, needed_roles=allowed)
+
+
+def enforce_registration_invariants(
+    tools: Iterable[tuple[str, SideEffect | None, Iterable[str], bool]],
+) -> None:
+    """Boot-time invariant sweep over registered tools (``INV-RBAC``). Fail-closed.
+
+    Args:
+        tools: An iterable of ``(name, side_effect, allowed_roles, requires_approval)``
+            quadruples.
+
+    Raises:
+        RegistryInvariantError: if any tool lacks ``side_effect`` metadata, any
+            ``write``/``execute`` tool lacks ``allowed_roles``, or any
+            ``write``/``execute`` tool is registered in a way that bypasses approval
+            enforcement (``requires_approval`` not set). Aggregated so the operator
+            sees every offending tool at once.
+    """
+    offenders: list[str] = []
+    for name, side_effect, allowed_roles, requires_approval in tools:
+        if side_effect is None:
+            offenders.append(f'{name}: missing side_effect metadata')
+            continue
+        if side_effect in SIDE_EFFECTING and not set(allowed_roles):
+            offenders.append(f'{name}: side-effecting ({side_effect.value}) without allowed_roles')
+        if side_effect in SIDE_EFFECTING and not requires_approval:
+            offenders.append(
+                f'{name}: side-effecting ({side_effect.value}) bypasses approval enforcement'
+            )
+    if offenders:
+        raise RegistryInvariantError(
+            'RBAC metadata invariant violated for: ' + '; '.join(sorted(offenders))
+        )

--- a/services/api-gateway/src/runtime/registry.py
+++ b/services/api-gateway/src/runtime/registry.py
@@ -14,17 +14,22 @@
 # See the LICENSE file in the project root for the full license text.
 
 """Thread-safe runtime Tool Registry for AstraDesk agents. Provides deterministic
-    registration/lookup/execution of domain tools (actions) with soft RBAC checks,
-    metadata (schema, version, description), and dynamic Domain Pack loading via
-    entry points (`astradesk.pack`).
+    registration/lookup/execution of domain tools (actions) and is the single RBAC
+    choke point (ISSUE 016), with metadata (side_effect, allowed_roles, schema,
+    version, description) and dynamic Domain Pack loading via entry points
+    (`astradesk.pack`).
 
 
 Overview
 --------
-- Metadata-first design: each tool is described by `ToolInfo` (name, version,
-  description, allowed_roles, schema), enabling auditability and UI introspection.
-- Soft RBAC: verifies caller's roles (from `claims`) against `allowed_roles`
-  using `runtime.policy.get_roles` when available (with a safe local fallback).
+- Metadata-first design: each tool is described by `ToolInfo` (name, side_effect,
+  allowed_roles, requires_approval, version, description, schema), enabling
+  auditability and UI introspection.
+- Fail-closed RBAC choke point: `execute()` authorizes every invocation through
+  `runtime.authz.authorize_tool` from *normalized roles* (never raw IdP claims),
+  so the LLM-planned and keyword-fallback paths enforce identically
+  (`INV-DUAL-PATH`). `side_effect` is mandatory at registration; a `write`/
+  `execute` tool without `allowed_roles` is rejected at registration (fail fast).
 - Unified execution: async callables awaited directly; sync callables executed
   via `asyncio.to_thread`, with exceptions logged and re-raised.
 - Domain Packs: discoverable through `importlib.metadata.entry_points(group="astradesk.pack")`;
@@ -33,14 +38,15 @@ Overview
 Responsibilities
 ----------------
 - Registration API:
-  * `register(name, fn, *, description, version, allowed_roles, schema, override)`
+  * `register(name, fn, *, side_effect, description, version, allowed_roles,
+    requires_approval, schema, override)`
   * `unregister(name)`
 - Read/Query API:
-  * `get(name)`, `get_info(name)`, `exists(name)`, `names()`
+  * `get(name)`, `get_info(name)`, `exists(name)`, `names()`, `infos()`
 - Execution:
-  * `execute(name, **kwargs)` — performs RBAC check (if configured), strips
-    meta-kwargs (e.g., `claims`) when not accepted by the callable’s signature,
-    then runs async/sync accordingly.
+  * `execute(name, *, roles=None, approval_id=None, **kwargs)` — authorizes via
+    the shared RBAC choke point (fail-closed), strips meta-kwargs (e.g., `claims`)
+    when not accepted by the callable’s signature, then runs async/sync.
 - Domain Packs:
   * `load_domain_packs()` — discovers and initializes packs; errors of individual
     packs are logged but do not block startup.
@@ -109,6 +115,8 @@ from typing import Any
 
 __all__ = [
     'AuthorizationError',
+    'RbacDenied',
+    'SideEffect',
     'ToolInfo',
     'ToolNotFoundError',
     'ToolRegistrationError',
@@ -118,35 +126,26 @@ __all__ = [
 ]
 
 
-from runtime.policy import get_roles as _policy_get_roles
-
-
-class AuthorizationError(PermissionError):
-    """Registry authorization failure with a stable public exception type."""
-
-
-def get_roles(claims: dict[str, Any] | None) -> list[str]:
-    """Extract roles through runtime policy when available, otherwise use the local parser."""
-    return _policy_get_roles(claims)
-
+from runtime.authz import (
+    APPROVAL_FIELDS,
+    AuthorizationError,
+    RbacDenied,
+    SideEffect,
+    approval_from_mapping,
+    authorize_tool,
+    coerce_side_effect,
+    roles_from_claims,
+    validate_tool_metadata,
+)
+from runtime.authz import (
+    SIDE_EFFECTING as _SIDE_EFFECTING,
+)
 
 # Logowanie
 _logger = logging.getLogger(__name__)
 
 # Utils
 _TOOL_NAME_RE = re.compile(r'^[A-Za-z0-9._-]{1,128}$')
-
-
-def _normalize_roles(value: Any) -> list[str]:
-    """Ujednolica kształt ról do list[str]. Akceptuje str (CSV), list/tuple/set."""
-    if value is None:
-        return []
-    if isinstance(value, str):
-        parts = [p.strip() for p in value.split(',') if p.strip()]
-        return parts or [value]
-    if isinstance(value, list | tuple | set):
-        return [str(v) for v in value]
-    return []
 
 
 def load_domain_packs(registry: ToolRegistry) -> list[tuple[str, Any]]:
@@ -206,13 +205,20 @@ ToolCallable = Callable[..., Any]
 
 @dataclass
 class ToolInfo:
-    """Metadane zarejestrowanego narzędzia runtime."""
+    """Metadane zarejestrowanego narzędzia runtime.
+
+    ``side_effect`` and ``allowed_roles`` are the source of truth for the RBAC
+    choke point (ISSUE 016). ``side_effect`` is mandatory at registration; a
+    ``write``/``execute`` tool must also carry a non-empty ``allowed_roles``.
+    """
 
     name: str
     fn: ToolCallable
+    side_effect: SideEffect
     description: str = ''
     version: str = '1.0.0'
     allowed_roles: set[str] = field(default_factory=set)
+    requires_approval: bool = False
     schema: dict[str, Any] = field(default_factory=dict)
 
     # Cache techniczny - nie eksponujemy w repr, ustawiany podczas register()
@@ -235,16 +241,29 @@ class ToolRegistry:
         name: str,
         fn: ToolCallable,
         *,
+        side_effect: SideEffect | str | None = None,
         description: str = '',
         version: str = '1.0.0',
         allowed_roles: set[str] | None = None,
+        requires_approval: bool = False,
         schema: dict[str, Any] | None = None,
         override: bool = False,
     ) -> None:
         """Rejestruje narzędzie; użyj override=True aby zastąpić istniejące.
 
+        RBAC metadata (ISSUE 016):
+            ``side_effect`` is mandatory and must be one of ``read``/``write``/
+            ``execute``. A ``write``/``execute`` tool must declare a non-empty
+            ``allowed_roles`` set, and approval enforcement is forced on for it
+            (``requires_approval`` is set by invariant regardless of the argument)
+            so a side-effecting tool can never be registered in a way that bypasses
+            the approval/change-record gate (``INV-RBAC-4``). All invariants are
+            enforced here so a mis-declared tool fails fast at boot, not at the
+            first unauthorized call (``INV-FAIL-CLOSED``).
+
         Raises:
-            ToolRegistrationError: niepoprawna nazwa/funkcja lub konflikt bez override.
+            ToolRegistrationError: niepoprawna nazwa/funkcja, brakujące lub
+                niepoprawne metadane RBAC, lub konflikt bez override.
 
         """
         if not name or not _TOOL_NAME_RE.fullmatch(name):
@@ -254,12 +273,25 @@ class ToolRegistry:
         if not callable(fn):
             raise ToolRegistrationError('fn must be callable')
 
+        roles = set(allowed_roles or set())
+        try:
+            effect = coerce_side_effect(side_effect)
+            validate_tool_metadata(name, effect, roles)
+        except ValueError as exc:
+            raise ToolRegistrationError(str(exc)) from exc
+
+        # Side-effecting tools always require an approval/change record (INV-RBAC-4);
+        # the flag can only ever be strengthened, never relaxed, at registration.
+        effective_requires_approval = bool(requires_approval) or effect in _SIDE_EFFECTING
+
         info = ToolInfo(
             name=name,
             fn=fn,
+            side_effect=effect,
             description=description or '',
             version=version or '1.0.0',
-            allowed_roles=set(allowed_roles or set()),
+            allowed_roles=roles,
+            requires_approval=effective_requires_approval,
             schema=dict(schema or {}),
         )
 
@@ -315,52 +347,87 @@ class ToolRegistry:
         """Lista nazw zarejestrowanych narzędzi."""
         return list(self._tools.keys())
 
+    def infos(self) -> list[ToolInfo]:
+        """Snapshot of all registered tool metadata (for boot-time invariants)."""
+        return list(self._tools.values())
+
     def exists(self, name: str) -> bool:
         """Czy narzędzie jest zarejestrowane?"""
         return name in self._tools
 
     # Wykonanie
-    async def execute(self, name: str, **kwargs: Any) -> Any:
-        """Uruchamia narzędzie z przekazanymi argumentami.
+    async def execute(
+        self,
+        name: str,
+        *,
+        roles: Iterable[str] | None = None,
+        approval_id: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Uruchamia narzędzie — jedyny punkt egzekwowania RBAC (ISSUE 016).
 
-        RBAC:
-            Jeśli ToolInfo.allowed_roles nie jest puste, wymagamy co najmniej jednej
-            roli wspólnej z rolami wyciągniętymi z `claims` (np. z JWT).
+        This is the single authorization choke point that both the LLM-planned
+        and keyword-fallback paths traverse (``INV-DUAL-PATH``). The decision is
+        delegated to :func:`runtime.authz.authorize_tool` and made from
+        *normalized roles only*.
+
+        Args:
+            roles: The principal's normalized roles. When ``None`` (legacy
+                callers) they are derived from ``claims`` via the compatibility
+                adapter; RBAC never inspects raw IdP claim shapes directly.
+            approval_id: Optional explicit approval/change-record id. When not
+                given, one is resolved from the invocation arguments / context via
+                the accepted fields (``approval_id``/``change_record``/
+                ``change_record_id``). ``write``/``execute`` tools are denied
+                (``APPROVAL_REQUIRED``) before execution if none is present
+                (``INV-RBAC-4``).
 
         Sync/Async:
             - Funkcje asynchroniczne awaitujemy bezpośrednio.
             - Funkcje synchroniczne odpalamy w wątku (`asyncio.to_thread`).
 
         Raises:
-            AuthorizationError: brak wymaganej roli.
+            RbacDenied: gdy wywołanie nie jest autoryzowane (przed wykonaniem fn).
             ToolNotFoundError: gdy narzędzie nie istnieje.
             Dowolny wyjątek biznesowy narzędzia (przepuszczamy, ale logujemy).
 
         """
         info = self.get_info(name)
 
-        # 1 RBAC (jeśli skonfigurowano allowed_roles)
-        if info.allowed_roles:
-            claims = kwargs.get('claims')
-            roles = set(_normalize_roles(get_roles(claims)))
-            if not roles.intersection(info.allowed_roles):
-                needed = sorted(info.allowed_roles)
-                _logger.warning(
-                    "RBAC deny: tool='%s' user_roles=%s need_any=%s",
-                    name,
-                    sorted(roles),
-                    needed,
-                )
-                raise AuthorizationError(
-                    f"Access denied: need any of roles {needed} for tool '{name}'."
-                )
+        # 1 RBAC choke point (shared by every execution path; fail-closed).
+        effective_roles = roles_from_claims(kwargs.get('claims')) if roles is None else roles
+        # Approval/change-record id may arrive explicitly or in the invocation
+        # arguments/context; the explicit value takes precedence.
+        effective_approval_id = approval_id or approval_from_mapping(kwargs)
+        try:
+            authorize_tool(
+                tool=name,
+                side_effect=info.side_effect,
+                allowed_roles=info.allowed_roles,
+                roles=effective_roles,
+                requires_approval=info.requires_approval,
+                approval_id=effective_approval_id,
+            )
+        except RbacDenied as exc:
+            _logger.warning(
+                "RBAC deny: tool='%s' reason=%s need_any=%s",
+                name,
+                exc.reason.value,
+                list(exc.needed_roles),
+            )
+            raise
 
-        # 2 Czyszczenie kwargs:
-        #    'claims' to meta - jeśli funkcja nie przyjmuje 'claims', nie przekazujemy go.
+        # 2 Czyszczenie kwargs: meta keys ('claims' and the approval fields) are
+        #    stripped when the callable does not declare them, so they never leak
+        #    into business tool signatures.
         sig = info.signature
-        if sig is not None and 'claims' not in sig.parameters and 'claims' in kwargs:
-            kwargs = dict(kwargs)  # płytka kopia
-            kwargs.pop('claims', None)
+        if sig is not None:
+            meta_keys = [k for k in ('claims', *APPROVAL_FIELDS) if k in kwargs]
+            to_strip = [k for k in meta_keys if k not in sig.parameters]
+            if to_strip:
+                kwargs = dict(kwargs)  # płytka kopia
+                for key in to_strip:
+                    kwargs.pop(key, None)
 
         # 3 Uruchomienie narzędzia obsługa sync/async
         if info.is_coroutine:

--- a/services/api-gateway/tests/runtime/test_gateway_ingress.py
+++ b/services/api-gateway/tests/runtime/test_gateway_ingress.py
@@ -54,11 +54,17 @@ class _RecordingVerifier:
 class _RecordingOrchestrator:
     def __init__(self) -> None:
         self.calls: list[tuple[AgentRequest, dict[str, Any], str]] = []
+        self.roles: list[tuple[str, ...]] = []
 
     async def run(
-        self, request: AgentRequest, claims: dict[str, Any], request_id: str
+        self,
+        request: AgentRequest,
+        claims: dict[str, Any],
+        request_id: str,
+        roles: tuple[str, ...] = (),
     ) -> AgentResponse:
         self.calls.append((request, claims, request_id))
+        self.roles.append(tuple(roles))
         return AgentResponse(
             output='Ingress accepted the authenticated request.',
             reasoning_trace_id=request_id,
@@ -130,6 +136,9 @@ def test_authenticated_request_reaches_handler_with_verified_claims(
     assert request.agent.value == 'support'
     assert claims == dict(_PRINCIPAL.claims)
     assert request_id == _REQUEST_ID
+    # Normalized roles from the verified principal are forwarded to the
+    # orchestrator and feed the RBAC choke point (ISSUE 016).
+    assert orchestrator.roles == [tuple(_PRINCIPAL.roles)]
 
 
 def test_healthz_remains_public_and_bypasses_verifier(

--- a/services/api-gateway/tests/runtime/test_rbac_invariant.py
+++ b/services/api-gateway/tests/runtime/test_rbac_invariant.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/tests/runtime/test_rbac_invariant.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Verifies AstraDesk behavior for the associated component.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""RBAC invariant tests for the single tool-execution choke point (ISSUE 016).
+
+These tests verify that authorization is a property of the tool invocation, not
+of the code path that produced it. The same ``ToolRegistry.execute`` choke point
+is exercised exactly as the LLM-planned path (orchestrator) and the
+keyword-fallback path (agents) call it, and the dual-path negative matrix asserts
+that an unauthorized side-effect call is denied identically in every cell.
+"""
+
+from __future__ import annotations
+
+import pytest
+from runtime.authz import (
+    AuthorizationError,
+    RbacDenied,
+    RbacReason,
+    RegistryInvariantError,
+    SideEffect,
+    authorize_tool,
+    enforce_registration_invariants,
+)
+from runtime.planner import KeywordPlanner
+from runtime.registry import ToolRegistrationError, ToolRegistry
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Spy:
+    """Records whether the underlying tool function was invoked.
+
+    ``as_tool`` returns a genuine coroutine function so the registry awaits it on
+    the real async execution path.
+    """
+
+    def __init__(self) -> None:
+        self.called = False
+
+    def as_tool(self):  # returns an async tool callable
+        async def fn(*, service: str = '', **_: object) -> str:
+            self.called = True
+            return f'executed:{service}'
+
+        return fn
+
+
+async def _register_side_effect_tool(
+    registry: ToolRegistry,
+    spy: _Spy,
+    *,
+    name: str = 'restart_service',
+    side_effect: SideEffect = SideEffect.EXECUTE,
+    allowed_roles: set[str] | None = None,
+) -> None:
+    await registry.register(
+        name,
+        spy.as_tool(),
+        side_effect=side_effect,
+        allowed_roles=allowed_roles if allowed_roles is not None else {'sre'},
+        description='side-effecting test tool',
+    )
+
+
+# === 1. Authorized side-effect call executes ============================== #
+
+
+async def test_side_effect_tool_with_matching_role_and_approval_executes() -> None:
+    registry = ToolRegistry()
+    spy = _Spy()
+    await _register_side_effect_tool(registry, spy)
+
+    result = await registry.execute(
+        'restart_service', roles=('sre',), approval_id='CHG-1001', service='webapp'
+    )
+
+    assert result == 'executed:webapp'
+    assert spy.called is True
+
+
+# === 2 & 6. Unauthorized call denied and underlying fn not invoked ========= #
+
+
+async def test_side_effect_tool_without_matching_role_is_denied() -> None:
+    registry = ToolRegistry()
+    spy = _Spy()
+    await _register_side_effect_tool(registry, spy)
+
+    with pytest.raises(RbacDenied) as excinfo:
+        await registry.execute('restart_service', roles=('viewer',), service='webapp')
+
+    assert excinfo.value.reason is RbacReason.ROLE_DENIED
+    assert spy.called is False  # denied before execution
+
+
+# === 3. Missing allowed_roles on a side-effect tool fails closed =========== #
+
+
+async def test_side_effect_tool_missing_allowed_roles_is_rejected_at_registration() -> None:
+    registry = ToolRegistry()
+    spy = _Spy()
+
+    with pytest.raises(ToolRegistrationError):
+        await registry.register(
+            'restart_service', spy, side_effect=SideEffect.WRITE, allowed_roles=set()
+        )
+
+
+async def test_boot_invariant_aborts_for_roleless_side_effect_tool() -> None:
+    # Even if a roleless side-effect tool reached the registry, the boot-time
+    # sweep aborts startup (fail-closed) rather than waiting for a call.
+    with pytest.raises(RegistryInvariantError):
+        enforce_registration_invariants([('rogue_write', SideEffect.WRITE, set(), True)])
+
+
+# === 4. Missing side_effect metadata is rejected at registry validation ==== #
+
+
+async def test_missing_side_effect_metadata_is_rejected_at_registration() -> None:
+    registry = ToolRegistry()
+
+    async def tool(**_: object) -> str:
+        return 'ok'
+
+    with pytest.raises(ToolRegistrationError):
+        await registry.register('mystery', tool)  # no side_effect declared
+
+
+async def test_boot_invariant_aborts_for_missing_side_effect_metadata() -> None:
+    with pytest.raises(RegistryInvariantError):
+        enforce_registration_invariants([('mystery', None, set(), False)])
+
+
+async def test_boot_invariant_aborts_when_side_effect_tool_bypasses_approval() -> None:
+    # A write/execute tool registered without approval enforcement is a bypass
+    # of INV-RBAC-4 and must abort startup.
+    with pytest.raises(RegistryInvariantError):
+        enforce_registration_invariants([('rogue_exec', SideEffect.EXECUTE, {'sre'}, False)])
+
+
+# === 5. Read-only tool with side_effect=read works without roles =========== #
+
+
+async def test_read_only_tool_without_roles_executes() -> None:
+    registry = ToolRegistry()
+    spy = _Spy()
+    await registry.register(
+        'get_metrics', spy.as_tool(), side_effect=SideEffect.READ, description='read-only'
+    )
+
+    result = await registry.execute('get_metrics', roles=(), service='webapp')
+
+    assert result == 'executed:webapp'
+    assert spy.called is True
+
+
+# === 7 & 8. Dual-path negative matrix: LLM-planned vs keyword-fallback ===== #
+
+
+async def _invoke_as_agent_path(
+    registry: ToolRegistry,
+    name: str,
+    roles: tuple[str, ...],
+    *,
+    approval_id: str | None = None,
+    **args: object,
+) -> object:
+    """Mirror the exact call both runtime paths make to the choke point.
+
+    The orchestrator (LLM path) and BaseAgent/OpsAgent/... (keyword-fallback
+    path) both call
+    ``self.tools.execute(step.name, roles=..., approval_id=..., claims=..., **args)``.
+    Routing the test through this single helper proves authority does not depend
+    on which planner produced the step (``INV-DUAL-PATH``).
+    """
+    return await registry.execute(name, roles=roles, approval_id=approval_id, claims={}, **args)
+
+
+@pytest.mark.parametrize('path', ['llm_planned', 'keyword_fallback'])
+async def test_dual_path_unauthorized_side_effect_is_denied(path: str) -> None:
+    registry = ToolRegistry()
+    spy = _Spy()
+    await _register_side_effect_tool(registry, spy)
+
+    if path == 'keyword_fallback':
+        # The deterministic planner resolves the side-effecting step itself.
+        steps = KeywordPlanner().make_plan('please restart webapp now')
+        assert steps and steps[0].name == 'restart_service'
+        name, args = steps[0].name, steps[0].arguments
+    else:
+        # The LLM planner would emit an equivalent resolved step.
+        name, args = 'restart_service', {'service': 'webapp'}
+
+    with pytest.raises(RbacDenied) as excinfo:
+        await _invoke_as_agent_path(registry, name, ('viewer',), **args)
+
+    assert excinfo.value.reason is RbacReason.ROLE_DENIED
+    assert spy.called is False
+
+
+@pytest.mark.parametrize('path', ['llm_planned', 'keyword_fallback'])
+async def test_dual_path_authorized_side_effect_executes(path: str) -> None:
+    registry = ToolRegistry()
+    spy = _Spy()
+    await _register_side_effect_tool(registry, spy)
+
+    if path == 'keyword_fallback':
+        steps = KeywordPlanner().make_plan('please restart webapp now')
+        name, args = steps[0].name, steps[0].arguments
+    else:
+        name, args = 'restart_service', {'service': 'webapp'}
+
+    result = await _invoke_as_agent_path(registry, name, ('sre',), approval_id='CHG-2002', **args)
+
+    assert result == 'executed:webapp'
+    assert spy.called is True
+
+
+# === INV-RBAC-4: approval/change-record hard gate on both paths =========== #
+
+
+@pytest.mark.parametrize('path', ['llm_planned', 'keyword_fallback'])
+@pytest.mark.parametrize('side_effect', [SideEffect.WRITE, SideEffect.EXECUTE])
+async def test_dual_path_authorized_role_missing_approval_is_denied(
+    path: str, side_effect: SideEffect
+) -> None:
+    # A matching role is NOT sufficient for write/execute: absence of an
+    # approval/change record denies before the tool function runs (INV-RBAC-4).
+    registry = ToolRegistry()
+    spy = _Spy()
+    await _register_side_effect_tool(registry, spy, side_effect=side_effect, allowed_roles={'sre'})
+
+    if path == 'keyword_fallback':
+        steps = KeywordPlanner().make_plan('please restart webapp now')
+        name, args = steps[0].name, steps[0].arguments
+    else:
+        name, args = 'restart_service', {'service': 'webapp'}
+
+    with pytest.raises(RbacDenied) as excinfo:
+        await _invoke_as_agent_path(registry, name, ('sre',), **args)  # no approval
+
+    assert excinfo.value.reason is RbacReason.APPROVAL_REQUIRED
+    assert spy.called is False
+
+
+@pytest.mark.parametrize('path', ['llm_planned', 'keyword_fallback'])
+@pytest.mark.parametrize('side_effect', [SideEffect.WRITE, SideEffect.EXECUTE])
+@pytest.mark.parametrize('approval_field', ['approval_id', 'change_record', 'change_record_id'])
+async def test_dual_path_authorized_role_with_approval_executes(
+    path: str, side_effect: SideEffect, approval_field: str
+) -> None:
+    # Authorized role + approval/change record (supplied via any accepted field
+    # name, here through the invocation arguments) executes on both paths.
+    registry = ToolRegistry()
+    spy = _Spy()
+    await _register_side_effect_tool(registry, spy, side_effect=side_effect, allowed_roles={'sre'})
+
+    if path == 'keyword_fallback':
+        steps = KeywordPlanner().make_plan('please restart webapp now')
+        name, args = steps[0].name, dict(steps[0].arguments)
+    else:
+        name, args = 'restart_service', {'service': 'webapp'}
+
+    args[approval_field] = 'CHG-3003'  # approval id arriving via invocation args
+
+    result = await _invoke_as_agent_path(registry, name, ('sre',), **args)
+
+    assert result == 'executed:webapp'
+    assert spy.called is True
+
+
+# === 9. Empty-role principal denied for write/execute ====================== #
+
+
+async def test_empty_roles_denied_for_write_and_execute() -> None:
+    registry = ToolRegistry()
+    write_spy, exec_spy = _Spy(), _Spy()
+    await _register_side_effect_tool(
+        registry,
+        write_spy,
+        name='create_ticket',
+        side_effect=SideEffect.WRITE,
+        allowed_roles={'it.support'},
+    )
+    await _register_side_effect_tool(
+        registry,
+        exec_spy,
+        name='restart_service',
+        side_effect=SideEffect.EXECUTE,
+        allowed_roles={'sre'},
+    )
+
+    with pytest.raises(RbacDenied):
+        await registry.execute('create_ticket', roles=(), service='x')
+    with pytest.raises(RbacDenied):
+        await registry.execute('restart_service', roles=(), service='x')
+
+    assert write_spy.called is False
+    assert exec_spy.called is False
+
+
+# === 10. Denial response does not leak claims/token/secrets ================ #
+
+
+async def test_denial_does_not_leak_claims_or_secrets() -> None:
+    registry = ToolRegistry()
+    spy = _Spy()
+    await _register_side_effect_tool(registry, spy)
+
+    secret_token = 'eyJhbGciOiJ.SUPER-SECRET-TOKEN.sig'
+    leaky_claims = {
+        'sub': 'user-1',
+        'roles': ['viewer'],
+        'access_token': secret_token,
+        'password': 'hunter2',
+    }
+
+    with pytest.raises(RbacDenied) as excinfo:
+        await registry.execute(
+            'restart_service', roles=('viewer',), claims=leaky_claims, service='webapp'
+        )
+
+    rendered = f'{excinfo.value!s} {excinfo.value!r}'
+    assert secret_token not in rendered
+    assert 'SUPER-SECRET-TOKEN' not in rendered
+    assert 'hunter2' not in rendered
+    assert 'access_token' not in rendered
+    # Only the tool name, the stable reason code, and required roles are exposed.
+    assert 'restart_service' in rendered
+    assert excinfo.value.reason.value == 'RBAC_DENIED'
+
+
+# === Choke-point unit coverage: reasons and approval gating ================ #
+
+
+async def test_authorize_tool_missing_metadata_denies() -> None:
+    with pytest.raises(RbacDenied) as excinfo:
+        authorize_tool(tool='x', side_effect=None, allowed_roles=set(), roles=('sre',))
+    assert excinfo.value.reason is RbacReason.METADATA_MISSING
+
+
+async def test_authorize_tool_requires_approval_when_marked() -> None:
+    with pytest.raises(RbacDenied) as excinfo:
+        authorize_tool(
+            tool='restart_service',
+            side_effect=SideEffect.EXECUTE,
+            allowed_roles={'sre'},
+            roles=('sre',),
+            requires_approval=True,
+            approval_id=None,
+        )
+    assert excinfo.value.reason is RbacReason.APPROVAL_REQUIRED
+
+    # With an approval id present, the same authorized principal passes.
+    authorize_tool(
+        tool='restart_service',
+        side_effect=SideEffect.EXECUTE,
+        allowed_roles={'sre'},
+        roles=('sre',),
+        requires_approval=True,
+        approval_id='CHG-123',
+    )
+
+
+async def test_rbac_denied_is_authorization_error() -> None:
+    # Backward-compatible exception hierarchy for existing call sites.
+    assert issubclass(RbacDenied, AuthorizationError)

--- a/services/api-gateway/tests/runtime/test_registry.py
+++ b/services/api-gateway/tests/runtime/test_registry.py
@@ -32,8 +32,7 @@ import asyncio
 from typing import Any
 
 import pytest
-
-from src.runtime.registry import (
+from runtime.registry import (
     AuthorizationError,
     ToolInfo,
     ToolNotFoundError,
@@ -59,7 +58,7 @@ async def test_register_and_execute_async_tool(registry: ToolRegistry) -> None:
         await asyncio.sleep(0)  # symulacja async
         return a * 2
 
-    await registry.register('double', double, description='x2')
+    await registry.register('double', double, side_effect='read', description='x2')
     assert registry.exists('double')
     assert 'double' in registry.names()
 
@@ -73,7 +72,7 @@ async def test_register_and_execute_sync_tool(registry: ToolRegistry) -> None:
     def inc(a: int, **_: dict[str, Any]) -> int:
         return a + 1
 
-    await registry.register('inc', inc)
+    await registry.register('inc', inc, side_effect='read')
 
     result: int = await registry.execute('inc', a=1)
     assert result == 2
@@ -88,7 +87,7 @@ async def test_rbac_access_denied(registry: ToolRegistry) -> None:
     def secret(**_: dict[str, Any]) -> str:
         return 'ok'
 
-    await registry.register('secret', secret, allowed_roles={'admin'})
+    await registry.register('secret', secret, side_effect='read', allowed_roles={'admin'})
 
     with pytest.raises(AuthorizationError):
         await registry.execute('secret', claims={'roles': ['user']})
@@ -100,7 +99,7 @@ async def test_rbac_access_allowed_with_single_role_in_list(registry: ToolRegist
     def secret(**_: dict[str, Any]) -> str:
         return 'ok'
 
-    await registry.register('secret', secret, allowed_roles={'admin'})
+    await registry.register('secret', secret, side_effect='read', allowed_roles={'admin'})
 
     result: str = await registry.execute('secret', claims={'roles': ['admin']})
     assert result == 'ok'
@@ -112,7 +111,7 @@ async def test_rbac_access_allowed_with_multiple_roles_in_list(registry: ToolReg
     def secret(**_: dict[str, Any]) -> str:
         return 'ok'
 
-    await registry.register('secret', secret, allowed_roles={'admin'})
+    await registry.register('secret', secret, side_effect='read', allowed_roles={'admin'})
 
     result: str = await registry.execute('secret', claims={'roles': ['user', 'admin']})
     assert result == 'ok'
@@ -127,7 +126,7 @@ async def test_claims_are_not_passed_if_not_in_signature(registry: ToolRegistry)
     def echo(*, x: int) -> int:
         return x
 
-    await registry.register('echo', echo)
+    await registry.register('echo', echo, side_effect='read')
 
     result: int = await registry.execute('echo', x=7, claims={'roles': ['admin']})
     assert result == 7
@@ -139,7 +138,7 @@ async def test_claims_are_passed_if_in_signature(registry: ToolRegistry) -> None
     def echo_with_claims(*, x: int, claims: dict[str, Any] | None = None) -> dict[str, Any]:
         return {'x': x, 'claims': claims}
 
-    await registry.register('echo_with_claims', echo_with_claims)
+    await registry.register('echo_with_claims', echo_with_claims, side_effect='read')
 
     result: dict[str, Any] = await registry.execute(
         'echo_with_claims', x=5, claims={'user': 'alice'}
@@ -183,6 +182,7 @@ async def test_tool_info_contains_correct_metadata(registry: ToolRegistry) -> No
     await registry.register(
         'example',
         example_tool,
+        side_effect='read',
         description='An example tool.',
         version='2.0.0',
         schema=schema,
@@ -195,6 +195,7 @@ async def test_tool_info_contains_correct_metadata(registry: ToolRegistry) -> No
     assert info.version == '2.0.0'
     assert info.schema == schema
     assert info.allowed_roles == allowed_roles
+    assert info.side_effect.value == 'read'
     assert info.is_coroutine is False
 
 
@@ -203,7 +204,7 @@ async def test_tool_info_contains_correct_metadata(registry: ToolRegistry) -> No
 
 async def test_register_tool_with_invalid_name_raises_error(registry: ToolRegistry) -> None:
     """Testuje, że rejestracja narzędzia z niepoprawną nazwą rzuca ToolRegistrationError."""
-    from src.runtime.registry import ToolRegistrationError
+    from runtime.registry import ToolRegistrationError
 
     def tool() -> None:
         pass
@@ -214,7 +215,7 @@ async def test_register_tool_with_invalid_name_raises_error(registry: ToolRegist
 
 async def test_register_non_callable_raises_error(registry: ToolRegistry) -> None:
     """Testuje, że rejestracja nie-callable obiektu rzuca ToolRegistrationError."""
-    from src.runtime.registry import ToolRegistrationError
+    from runtime.registry import ToolRegistrationError
 
     with pytest.raises(ToolRegistrationError):
         await registry.register('bad_tool', 'not a function')  # type: ignore[arg-type]
@@ -230,7 +231,7 @@ async def test_async_tool_execution_awaits_properly(registry: ToolRegistry) -> N
         await asyncio.sleep(0.01)
         return x
 
-    await registry.register('delayed', delayed_echo)
+    await registry.register('delayed', delayed_echo, side_effect='read')
 
     result: int = await registry.execute('delayed', x=99)
     assert result == 99
@@ -245,7 +246,7 @@ async def test_sync_tool_execution_runs_in_thread(registry: ToolRegistry) -> Non
         time.sleep(0.01)  # symulacja operacji blokującej
         return x * 2
 
-    await registry.register('blocking', blocking_operation)
+    await registry.register('blocking', blocking_operation, side_effect='read')
 
     result: int = await registry.execute('blocking', x=5)
     assert result == 10
@@ -265,8 +266,8 @@ async def test_concurrent_registration_and_execution(registry: ToolRegistry) -> 
 
     # Zarejestruj dwa narzędzia współbieżnie
     await asyncio.gather(
-        registry.register('tool_a', tool_a),
-        registry.register('tool_b', tool_b),
+        registry.register('tool_a', tool_a, side_effect='read'),
+        registry.register('tool_b', tool_b, side_effect='read'),
     )
 
     # Wykonaj je współbieżnie


### PR DESCRIPTION
## Summary

Implements ISSUE 016: RBAC invariant on every side-effect path.

Authorization is now enforced as a property of tool invocation through a single choke point:

`ToolRegistry.execute(...) -> runtime.authz.authorize_tool(...)`

Both LLM-planned execution and keyword-fallback execution pass through this same registry execution path.

## Security invariants

- Every tool declares `side_effect`.
- `write` and `execute` tools require non-empty `allowed_roles`.
- Missing metadata fails fast.
- Unauthorized side-effect calls deny before the underlying tool function runs.
- `write` and `execute` require an approval/change record.
- A matching role alone is not enough for `write` or `execute`.
- Missing approval/change record denies with `APPROVAL_REQUIRED`.
- Denial messages do not expose raw claims, raw tokens, secrets, or credentials.
- RBAC consumes normalized roles and does not parse IdP-specific token shapes.

## Approval fields

Accepted approval/change-record fields:

- `approval_id`
- `change_record`
- `change_record_id`

These are stripped from tool kwargs before the underlying function is invoked.

## Scope

Changed:

- runtime authorization choke point
- tool registry metadata enforcement
- gateway built-in tool registration metadata
- orchestrator role/approval forwarding
- fallback agent role/approval forwarding
- RBAC invariant tests
- registry tests
- gateway ingress test double

Not changed:

- OIDC/JWKS/token verification
- Admin API contract
- OpenAPI
- Java ticket adapter internals
- durable audit #019
- PII egress boundary NEW-04

## Verification

```text
uv run ruff check core/src services/api-gateway/src services/api-gateway/tests
All checks passed!
uv run ruff format --check core/src services/api-gateway/src services/api-gateway/tests
51 files already formatted
uv run python scripts/license_headers.py --check
License headers verified; would normalize 0 file(s).
uv run pytest -q services/api-gateway/tests/runtime/test_rbac_invariant.py services/api-gateway/tests/runtime/test_registry.py
49 passed
uv run pytest -q services/api-gateway/tests
262 passed
uv run pytest -q --cov-report=xml:coverage.xml
297 passed, 2 warnings
Coverage XML written to file coverage.xml
uv run mypy services/api-gateway/src/runtime/authz.py

Known unrelated baseline:

services/api-gateway/src/runtime/policy.py:36: error: Module "opentelemetry" has no attribute "trace" [attr-defined]

policy.py is not modified by this PR.
