### PR TITLE
Add PII redaction and egress boundary

### DIFF
--- a/core/src/astradesk_core/egress.py
+++ b/core/src/astradesk_core/egress.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: core/src/astradesk_core/egress.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Implements AstraDesk functionality for core/src/astradesk_core/egress.py.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Fail-closed egress allow-list for model/tool/external sink targets.
+
+Implements ``INV-PII-3``: egress targets (model providers, external tools,
+sinks) are governed by an explicit allow-list; an unlisted target is denied.
+
+The allow-list is keyed by **hostname** (case-insensitive). The default set
+covers the framework's known production/internal targets. Operators extend it
+through the ``ASTRADESK_EGRESS_ALLOWLIST`` environment variable (comma- or
+whitespace-separated hostnames). The environment is read on each call so the
+policy is deterministic and trivially overridable in tests.
+
+Denials raise :class:`EgressDenied`, whose message contains only the target
+host and the egress category — never the payload, token, or claims.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Final
+from urllib.parse import urlsplit
+
+ENV_ALLOWLIST: Final = 'ASTRADESK_EGRESS_ALLOWLIST'
+
+# Named error code for observability/audit (see CLAUDE.md §3.3 ERR).
+ERROR_CODE: Final = 'EGRESS_DENIED'
+
+# Default allow-list: known AstraDesk model/tool/internal targets. Loopback is
+# included so local/dev/CI stacks (vLLM, local KB) are not denied by default.
+DEFAULT_ALLOWED_HOSTS: Final[frozenset[str]] = frozenset(
+    {
+        'localhost',
+        '127.0.0.1',
+        '::1',
+        # Model providers
+        'api.openai.com',
+        # External tool APIs used by built-in tools
+        'api.openweathermap.org',
+        # Internal cluster services (Istio mTLS targets)
+        'ticket-adapter.tickets.svc.cluster.local',
+        'kb-service',
+    }
+)
+
+
+class EgressDenied(Exception):
+    """Raised when an egress target is not on the allow-list (fail-closed).
+
+    The string form intentionally exposes only the offending host and the
+    egress category, so the error itself cannot leak raw input or secrets.
+    """
+
+    def __init__(self, host: str, category: str) -> None:
+        self.code = ERROR_CODE
+        self.host = host
+        self.category = category
+        super().__init__(f'{ERROR_CODE}: egress to {host!r} denied for category {category!r}')
+
+
+def _env_hosts() -> frozenset[str]:
+    raw = os.getenv(ENV_ALLOWLIST, '')
+    if not raw:
+        return frozenset()
+    parts = raw.replace(',', ' ').split()
+    return frozenset(host.strip().lower() for host in parts if host.strip())
+
+
+def allowed_hosts() -> frozenset[str]:
+    """Return the effective allow-list (defaults ∪ environment additions)."""
+    return DEFAULT_ALLOWED_HOSTS | _env_hosts()
+
+
+def host_of(target: str) -> str:
+    """Extract a lower-cased hostname from a URL or bare host string.
+
+    Accepts full URLs (``https://api.openai.com/v1``), host:port pairs, and
+    bare hostnames. Returns an empty string if no host can be determined —
+    which the enforcement path treats as denied (fail-closed).
+    """
+    if not target:
+        return ''
+    candidate = target.strip()
+    parsed = urlsplit(candidate if '//' in candidate else f'//{candidate}')
+    host = parsed.hostname or ''
+    return host.lower()
+
+
+def is_allowed(target: str) -> bool:
+    """Return whether ``target`` resolves to an allow-listed host."""
+    host = host_of(target)
+    if not host:
+        return False
+    return host in allowed_hosts()
+
+
+def ensure_allowed(target: str, *, category: str = 'external') -> str:
+    """Assert that ``target`` is allow-listed, returning its host on success.
+
+    Raises :class:`EgressDenied` (fail-closed) when the target is unlisted or
+    its host cannot be parsed. ``category`` is a coarse label (e.g. ``model``,
+    ``tool``, ``sink``) used only for observability — it carries no payload.
+    """
+    host = host_of(target)
+    if not host or host not in allowed_hosts():
+        raise EgressDenied(host or target, category)
+    return host

--- a/core/src/astradesk_core/redaction.py
+++ b/core/src/astradesk_core/redaction.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: core/src/astradesk_core/redaction.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Implements AstraDesk functionality for core/src/astradesk_core/redaction.py.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Deterministic PII/secret classification and redaction (``INV-NO-RAW-EGRESS``).
+
+This module is the single, shared boundary used by both the API Gateway runtime
+and the MCP Gateway to scrub raw user input, PII, secrets, tokens, and
+credentials *before* they reach any emitter (logs, span attributes, model
+payloads, tool payloads, audit previews, RAG traces).
+
+Design properties:
+
+- **Deterministic & testable**: redaction is a pure function of its input.
+- **Stable placeholders**: ``[REDACTED_EMAIL]``, ``[REDACTED_TOKEN]``,
+  ``[REDACTED_SECRET]``, ``[REDACTED_PRIVATE_KEY]`` etc. never change shape.
+- **Fail-closed**: if the redactor itself raises, callers receive a constant
+  placeholder, never the raw text (``INV-PII`` failure-mode contract).
+
+The detector set is intentionally conservative — this is a defensive ingress/
+egress boundary, not a full DLP product (see ISSUES_NEW-04 "Out of scope").
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Final
+
+# Category labels (also used by classification). Kept stable for assertions.
+CATEGORY_EMAIL: Final = 'email'
+CATEGORY_TOKEN: Final = 'token'
+CATEGORY_SECRET: Final = 'secret'
+CATEGORY_PRIVATE_KEY: Final = 'private_key'
+CATEGORY_IP: Final = 'ip'
+CATEGORY_CREDIT_CARD: Final = 'credit_card'
+CATEGORY_SSN: Final = 'ssn'
+
+# Stable, explicit placeholders. Never embed any portion of the matched text.
+PLACEHOLDER_EMAIL: Final = '[REDACTED_EMAIL]'
+PLACEHOLDER_TOKEN: Final = '[REDACTED_TOKEN]'
+PLACEHOLDER_SECRET: Final = '[REDACTED_SECRET]'
+PLACEHOLDER_PRIVATE_KEY: Final = '[REDACTED_PRIVATE_KEY]'
+PLACEHOLDER_IP: Final = '[REDACTED_IP]'
+PLACEHOLDER_CREDIT_CARD: Final = '[REDACTED_CC]'
+PLACEHOLDER_SSN: Final = '[REDACTED_SSN]'
+
+# Returned when the redactor itself fails. Fail-closed: never the raw value.
+REDACTION_FAILED: Final = '[REDACTION_FAILED]'
+
+# --------------------------------------------------------------------------- #
+# Detectors. Order matters: most specific / most sensitive first so that a
+# broader pattern cannot partially expose a value a narrower one would scrub.
+# Each entry is (category, compiled_pattern, replacement).
+# --------------------------------------------------------------------------- #
+_PRIVATE_KEY_BLOCK = re.compile(
+    r'-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----'
+    r'.*?'
+    r'-----END (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----',
+    re.DOTALL,
+)
+# Bare marker (e.g. truncated key) so a lone header line is still scrubbed.
+_PRIVATE_KEY_MARKER = re.compile(
+    r'-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----'
+)
+
+# "Authorization: Bearer <token>" — scrub the credential, keep the scheme word.
+_BEARER = re.compile(r'(?i)\bBearer\s+[A-Za-z0-9._\-+/=]+')
+
+# JSON Web Tokens (three dot-separated base64url segments starting with eyJ).
+_JWT = re.compile(r'\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+')
+
+# Well-known provider API-key shapes.
+_API_KEY_SHAPES = re.compile(
+    r'\b(?:'
+    r'sk-[A-Za-z0-9]{16,}'  # OpenAI-style
+    r'|ghp_[A-Za-z0-9]{20,}'  # GitHub PAT
+    r'|gho_[A-Za-z0-9]{20,}'
+    r'|xox[baprs]-[A-Za-z0-9-]{10,}'  # Slack
+    r'|AKIA[0-9A-Z]{16}'  # AWS access key id
+    r')\b'
+)
+
+# key=value / key: value secret assignments. Keep the key name, scrub the value.
+_SECRET_ASSIGNMENT = re.compile(
+    r'(?i)\b('
+    r'pass(?:word|wd)?'
+    r'|secret'
+    r'|api[_-]?key'
+    r'|apikey'
+    r'|token'
+    r'|access[_-]?key'
+    r'|client[_-]?secret'
+    r'|auth[_-]?token'
+    r')(\s*[:=]\s*)'
+    r"""(?:"[^"]*"|'[^']*'|[^\s,;]+)"""
+)
+
+_EMAIL = re.compile(r'\b[\w.+-]+@[\w-]+\.[\w.-]+\b')
+_SSN = re.compile(r'\b\d{3}-\d{2}-\d{4}\b')
+_CREDIT_CARD = re.compile(r'\b(?:\d[ -]?){13,16}\b')
+_IPV4 = re.compile(r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b')
+
+# Sequential redaction pipeline.
+_PIPELINE: Final[tuple[tuple[str, re.Pattern[str], str], ...]] = (
+    (CATEGORY_PRIVATE_KEY, _PRIVATE_KEY_BLOCK, PLACEHOLDER_PRIVATE_KEY),
+    (CATEGORY_PRIVATE_KEY, _PRIVATE_KEY_MARKER, PLACEHOLDER_PRIVATE_KEY),
+    (CATEGORY_TOKEN, _BEARER, f'Bearer {PLACEHOLDER_TOKEN}'),
+    (CATEGORY_TOKEN, _JWT, PLACEHOLDER_TOKEN),
+    (CATEGORY_TOKEN, _API_KEY_SHAPES, PLACEHOLDER_TOKEN),
+    (CATEGORY_SECRET, _SECRET_ASSIGNMENT, r'\1\2' + PLACEHOLDER_SECRET),
+    (CATEGORY_EMAIL, _EMAIL, PLACEHOLDER_EMAIL),
+    (CATEGORY_SSN, _SSN, PLACEHOLDER_SSN),
+    (CATEGORY_CREDIT_CARD, _CREDIT_CARD, PLACEHOLDER_CREDIT_CARD),
+    (CATEGORY_IP, _IPV4, PLACEHOLDER_IP),
+)
+
+# Patterns used purely for classification (detection without mutation).
+_CLASSIFIERS: Final[tuple[tuple[str, re.Pattern[str]], ...]] = tuple(
+    (category, pattern) for category, pattern, _ in _PIPELINE
+)
+
+
+def redact_text(text: str) -> str:
+    """Return ``text`` with all detected PII/secrets replaced by placeholders.
+
+    Fail-closed: any internal error yields :data:`REDACTION_FAILED`, never the
+    original input.
+    """
+    try:
+        if not text:
+            return text
+        redacted = text
+        for _category, pattern, replacement in _PIPELINE:
+            redacted = pattern.sub(replacement, redacted)
+        return redacted
+    except Exception:
+        # Never leak raw text on a redactor failure (INV-PII fail-closed).
+        return REDACTION_FAILED
+
+
+def classify(text: str) -> frozenset[str]:
+    """Return the set of sensitive-data categories detected in ``text``.
+
+    Fail-closed: on any internal error, conservatively report a sensitive
+    marker so downstream emitters treat the value as classified.
+    """
+    try:
+        if not text:
+            return frozenset()
+        found = {category for category, pattern in _CLASSIFIERS if pattern.search(text)}
+        return frozenset(found)
+    except Exception:
+        return frozenset({CATEGORY_SECRET})
+
+
+def is_sensitive(text: str) -> bool:
+    """Return whether ``text`` contains any detected PII/secret category."""
+    return bool(classify(text))
+
+
+def redact_value(value: object) -> object:
+    """Redact a scalar value, leaving non-text scalars (int/float/bool) intact.
+
+    Strings are redacted; ``None``/numbers/booleans pass through unchanged so
+    numeric span attributes (counts, scores) keep their native type. Other
+    objects are stringified and redacted (fail-closed).
+    """
+    if isinstance(value, str):
+        return redact_text(value)
+    if value is None or isinstance(value, bool | int | float):
+        return value
+    try:
+        return redact_text(str(value))
+    except Exception:
+        return REDACTION_FAILED
+
+
+def redact_mapping(data: Mapping[str, object]) -> dict[str, object]:
+    """Return a shallow copy of ``data`` with all string values redacted.
+
+    Useful for scrubbing tool/model payload previews before they are logged or
+    traced. Nested mappings are redacted recursively; sequences of strings are
+    redacted element-wise.
+    """
+    try:
+        result: dict[str, object] = {}
+        for key, value in data.items():
+            if isinstance(value, Mapping):
+                result[key] = redact_mapping(value)
+            elif isinstance(value, list | tuple):
+                result[key] = [redact_value(item) for item in value]
+            else:
+                result[key] = redact_value(value)
+        return result
+    except Exception:
+        return {'_redaction': REDACTION_FAILED}
+
+
+def safe_preview(text: str, max_chars: int = 100) -> str:
+    """Return a redacted, length-bounded preview safe for logs/spans.
+
+    Redaction happens *before* truncation so a placeholder is never split.
+    """
+    redacted = redact_text(text)
+    if max_chars <= 0:
+        return ''
+    if len(redacted) <= max_chars:
+        return redacted
+    return redacted[:max_chars]

--- a/mcp/src/clients/kb_client.py
+++ b/mcp/src/clients/kb_client.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
+from astradesk_core.egress import ensure_allowed
 
 
 @dataclass
@@ -64,6 +65,11 @@ class KnowledgeBaseClient:
         Returns:
             List of knowledge base entries
         """
+        # Fail-closed egress governance (INV-PII-3): the KB host must be on the
+        # allow-list before the query (potentially containing user input) is
+        # sent to an external target. An unlisted host raises EgressDenied.
+        ensure_allowed(self.base_url, category='tool')
+
         # Prepare the request payload
         payload = {'query': query, 'top_k': top_k}
 
@@ -99,6 +105,8 @@ class KnowledgeBaseClient:
         Returns:
             KnowledgeBaseEntry if found, None otherwise
         """
+        # Fail-closed egress governance (INV-PII-3) before any external call.
+        ensure_allowed(self.base_url, category='tool')
         try:
             # Make HTTP request to knowledge base API
             response = await self.http_client.get(f'{self.base_url}/entries/{entry_id}')

--- a/mcp/src/gateway/middleware.py
+++ b/mcp/src/gateway/middleware.py
@@ -18,17 +18,48 @@ MCP Gateway Middleware
 
 This module contains middleware implementations for the MCP Gateway:
 - MetricsMiddleware: Collects and exposes Prometheus metrics
-- PIIProtectionMiddleware: (Planned) Protection against PII exposure
+- TracingMiddleware: OpenTelemetry request tracing (redact-before-emit)
+- SecurityHeadersMiddleware: Adds hardening response headers
+- PIIProtectionMiddleware: Real ingress PII/secret classifier (fail-closed)
 """
 
+import logging
+import os
 import time
 from collections.abc import Awaitable, Callable
-from typing import ClassVar
 
+from astradesk_core.redaction import classify, redact_text
 from fastapi import Request, Response
+from fastapi.responses import JSONResponse
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 from starlette.middleware.base import BaseHTTPMiddleware
+
+logger = logging.getLogger(__name__)
+
+# Categories that, when detected in an ingress body, are hard secrets. When
+# block mode is enabled these are rejected fail-closed before the body can be
+# forwarded to any downstream tool/model.
+_BLOCKING_CATEGORIES = frozenset({'secret', 'private_key', 'token'})
+
+
+def _block_secrets_enabled() -> bool:
+    """Whether the gateway should reject requests carrying hard secrets."""
+    return os.getenv('MCP_PII_BLOCK_SECRETS', '0').lower() in ('1', 'true', 'yes')
+
+
+def _redacted_target(request: Request) -> str:
+    """Return a span-safe request target: scheme://host/path, query stripped.
+
+    URL query strings frequently carry tokens/credentials, so they are never
+    emitted. The path itself is redacted in case an identifier embedded in it
+    matches a sensitive pattern (INV-PII-1/INV-PII-4).
+    """
+    url = request.url
+    base = f'{url.scheme}://{url.hostname or ""}'
+    if url.port:
+        base = f'{base}:{url.port}'
+    return redact_text(f'{base}{url.path}')
 
 
 class MetricsMiddleware(BaseHTTPMiddleware):
@@ -55,9 +86,11 @@ class TracingMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         with self.tracer.start_as_current_span(f'{request.method} {request.url.path}') as span:
-            # Add request attributes to span
+            # Add request attributes to span. The full URL (with query string)
+            # is NEVER emitted — query strings carry tokens/credentials. We emit
+            # a redacted scheme://host/path target instead (INV-PII-1).
             span.set_attribute('http.method', request.method)
-            span.set_attribute('http.url', str(request.url))
+            span.set_attribute('http.target', _redacted_target(request))
             span.set_attribute('http.route', request.url.path)
 
             try:
@@ -94,18 +127,57 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 
 class PIIProtectionMiddleware(BaseHTTPMiddleware):
-    """Middleware for PII protection"""
+    """Real ingress PII/secret classifier for the MCP Gateway.
 
-    PII_PATTERNS: ClassVar[list[str]] = [
-        r'\b\d{3}-\d{2}-\d{4}\b',  # SSN
-        r'\b\d{16}\b',  # Credit card
-        r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',  # Email
-    ]
+    Replaces the previous no-op. On every request it:
+
+    1. Classifies the request body via the shared, deterministic detector set
+       (:mod:`astradesk_core.redaction`).
+    2. Attaches the detected categories to ``request.state.pii_classification``
+       so downstream handlers/audit can consult the classification
+       (``INV-PII-2``) and surfaces them on a span-safe response header
+       (category labels only — never raw values).
+    3. When ``MCP_PII_BLOCK_SECRETS`` is enabled and the body carries a hard
+       secret (token/secret/private key), rejects the request fail-closed with
+       422 before it can be forwarded downstream.
+
+    The raw body is never logged, traced, or echoed — only category labels and
+    redacted previews leave this boundary (``INV-PII-1``).
+    """
 
     async def dispatch(
         self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
-        # In a real implementation, you would scan request body for PII
-        # and either redact it or block the request
+        categories: frozenset[str] = frozenset()
+        try:
+            body = await request.body()
+            if body:
+                # decode defensively; classification never raises (fail-closed).
+                text = body.decode('utf-8', errors='replace')
+                categories = classify(text)
+        except Exception:
+            # If we cannot read/inspect the body, treat it as sensitive so the
+            # request is conservatively flagged rather than silently trusted.
+            logger.warning('PII classifier could not inspect request body')
+            categories = frozenset({'secret'})
+
+        request.state.pii_classification = sorted(categories)
+
+        if categories & _BLOCKING_CATEGORIES and _block_secrets_enabled():
+            # Audit-safe denial: report only the offending category labels.
+            blocked = sorted(categories & _BLOCKING_CATEGORIES)
+            logger.warning('Ingress blocked: secret-class data detected %s', blocked)
+            return JSONResponse(
+                status_code=422,
+                content={
+                    'error': 'pii_policy_violation',
+                    'detail': 'Request body contains secret-class data and was rejected.',
+                    'categories': blocked,
+                },
+                headers={'X-PII-Classification': ','.join(blocked)},
+            )
+
         response = await call_next(request)
+        if categories:
+            response.headers['X-PII-Classification'] = ','.join(sorted(categories))
         return response

--- a/mcp/tests/test_pii_middleware.py
+++ b/mcp/tests/test_pii_middleware.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: mcp/tests/test_pii_middleware.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Verifies AstraDesk behavior for the associated component.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""MCP Gateway ingress PII boundary + external-tool egress tests.
+
+Covers ISSUES_NEW-04: the real PII classifier replacing the no-op middleware,
+the redacted tracing target (no query strings on spans), and external tool
+egress denial for an unlisted target (required test 8).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from astradesk_core.egress import EgressDenied
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.requests import Request as StarletteRequest
+
+from mcp.src.clients.kb_client import KnowledgeBaseClient
+from mcp.src.gateway.middleware import (
+    PIIProtectionMiddleware,
+    _redacted_target,
+)
+
+_RAW_EMAIL = 'leak@example.com'
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(PIIProtectionMiddleware)
+
+    @app.post('/echo')
+    async def echo(request: Request) -> dict[str, object]:
+        # The handler returns a fixed body + the classification recorded by the
+        # middleware on request.state — never the raw body.
+        return {
+            'status': 'ok',
+            'classification': getattr(request.state, 'pii_classification', []),
+        }
+
+    return app
+
+
+def test_middleware_classifies_body_and_does_not_echo_raw() -> None:
+    client = TestClient(_build_app())
+    resp = client.post('/echo', content=f'please email {_RAW_EMAIL}')
+    assert resp.status_code == 200
+    assert _RAW_EMAIL not in resp.text
+    assert 'email' in resp.json()['classification']
+    assert 'email' in resp.headers.get('X-PII-Classification', '')
+
+
+def test_middleware_blocks_secret_class_body_in_block_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv('MCP_PII_BLOCK_SECRETS', '1')
+    client = TestClient(_build_app())
+    resp = client.post('/echo', content='api_key=supersecretvalue123')
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body['error'] == 'pii_policy_violation'
+    assert 'secret' in body['categories']
+    # The raw secret must never be echoed back.
+    assert 'supersecretvalue123' not in resp.text
+
+
+def test_middleware_allows_benign_body() -> None:
+    client = TestClient(_build_app())
+    resp = client.post('/echo', content='restart the webapp service')
+    assert resp.status_code == 200
+    assert resp.json()['classification'] == []
+    assert 'X-PII-Classification' not in resp.headers
+
+
+def test_redacted_target_strips_query_string_and_secrets() -> None:
+    scope = {
+        'type': 'http',
+        'method': 'GET',
+        'scheme': 'http',
+        'server': ('mcp-gateway', 8080),
+        'path': '/invoke',
+        'query_string': b'token=aaa.bbb.ccc&u=alice',
+        'headers': [],
+    }
+    request = StarletteRequest(scope)
+    target = _redacted_target(request)
+    assert 'aaa.bbb.ccc' not in target
+    assert 'token=' not in target
+    assert target.endswith('/invoke')
+
+
+@pytest.mark.asyncio
+async def test_kb_client_egress_denied_for_unlisted_host() -> None:
+    client = KnowledgeBaseClient('https://evil.attacker.example')
+    with pytest.raises(EgressDenied):
+        await client.search('any query', top_k=3)
+
+
+@pytest.mark.asyncio
+async def test_kb_client_egress_allowed_for_listed_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv('ASTRADESK_EGRESS_ALLOWLIST', 'kb.allowed.test')
+    client = KnowledgeBaseClient('https://kb.allowed.test')
+
+    fake_response = MagicMock()
+    fake_response.raise_for_status = MagicMock()
+    fake_response.json = MagicMock(
+        return_value={
+            'results': [
+                {'id': '1', 'title': 'T', 'content': 'C', 'metadata': {}},
+            ]
+        }
+    )
+    monkeypatch.setattr(client.http_client, 'post', AsyncMock(return_value=fake_response))
+
+    entries = await client.search('reset password', top_k=1)
+    assert len(entries) == 1
+    assert entries[0].id == '1'

--- a/services/api-gateway/src/agents/base.py
+++ b/services/api-gateway/src/agents/base.py
@@ -44,6 +44,7 @@ from pydantic import BaseModel
 from runtime.authz import approval_from_mapping
 from runtime.memory import Memory
 from runtime.models import ToolCall
+from runtime.pii import safe_preview
 from runtime.planner import KeywordPlanner
 from runtime.policy import policy as opa_policy
 from runtime.rag import RAG
@@ -211,7 +212,9 @@ class BaseAgent(ABC):
         """
         with self.tracer.start_as_current_span('agent_run') as span:
             span.set_attribute('agent_name', self.agent_name)
-            span.set_attribute('query', query)
+            # Raw user query must be redacted before reaching the span
+            # (INV-PII-1/INV-PII-4).
+            span.set_attribute('query_preview', safe_preview(query, 100))
 
             # Generate initial plan with retries
             initial_plan = None

--- a/services/api-gateway/src/agents/ops.py
+++ b/services/api-gateway/src/agents/ops.py
@@ -41,6 +41,7 @@ from opentelemetry import trace
 from runtime.authz import approval_from_mapping
 from runtime.memory import Memory
 from runtime.models import ToolCall
+from runtime.pii import safe_preview
 from runtime.planner import KeywordPlanner
 from runtime.policy import policy as opa_policy
 from runtime.rag import RAG, RAGSnippet
@@ -273,7 +274,8 @@ class OpsAgent(BaseAgent):
         user_id = claims.get('user_id', 'unknown')
 
         with self.tracer.start_as_current_span('ops.run') as span:
-            span.set_attribute('query', query[:100])
+            # Redact before the preview reaches the span (INV-PII-1).
+            span.set_attribute('query_preview', safe_preview(query, 100))
             span.set_attribute('user_id', user_id)
 
             try:

--- a/services/api-gateway/src/agents/support.py
+++ b/services/api-gateway/src/agents/support.py
@@ -41,6 +41,7 @@ from opentelemetry import trace
 from runtime.authz import approval_from_mapping
 from runtime.memory import Memory
 from runtime.models import ToolCall
+from runtime.pii import safe_preview
 from runtime.planner import KeywordPlanner
 from runtime.policy import policy as opa_policy
 from runtime.rag import RAG, RAGSnippet
@@ -281,7 +282,8 @@ class SupportAgent(BaseAgent):
         user_id = claims.get('user_id', 'unknown')
 
         with self.tracer.start_as_current_span('support.run') as span:
-            span.set_attribute('query', query[:100])
+            # Redact before the preview reaches the span (INV-PII-1).
+            span.set_attribute('query_preview', safe_preview(query, 100))
             span.set_attribute('user_id', user_id)
 
             try:

--- a/services/api-gateway/src/gateway/orchestrator.py
+++ b/services/api-gateway/src/gateway/orchestrator.py
@@ -35,6 +35,7 @@ from opentelemetry import trace  # AstraOps/OTel
 from runtime.authz import approval_from_mapping
 from runtime.memory import Memory
 from runtime.models import AgentRequest, AgentResponse, ToolCall
+from runtime.pii import attach_classification, safe_preview
 from runtime.registry import ToolRegistry
 
 import asyncpg
@@ -121,15 +122,21 @@ class AgentOrchestrator:
             PolicyViolationError: If OPA denies access.
         """
         with self.tracer.start_as_current_span('orchestrator.run') as span:
+            # Ingress boundary: classify the raw input once and propagate the
+            # classification with the request (INV-PII-2). Only a redacted,
+            # bounded preview reaches the span (INV-PII-1/INV-PII-4).
+            classification = attach_classification(req.input)
             span.set_attribute('request_id', request_id)
             span.set_attribute('agent', req.agent.value)
-            span.set_attribute('input_preview', req.input[:100])
+            span.set_attribute('input_preview', safe_preview(req.input, 100))
+            span.set_attribute('input_classification', sorted(classification))
 
             context = {
                 **req.meta,
                 'claims': claims,
                 'roles': tuple(roles),
                 'request_id': request_id,
+                'data_classification': sorted(classification),
             }
             memory = Memory(self.pg_pool, self.redis)
 

--- a/services/api-gateway/src/model_gateway/guardrails.py
+++ b/services/api-gateway/src/model_gateway/guardrails.py
@@ -24,6 +24,7 @@ import logging
 import re
 from typing import Any
 
+from astradesk_core.redaction import redact_text, safe_preview
 from opa_client.opa import OpaClient
 from opentelemetry import trace
 from pydantic import BaseModel, Field, ValidationError
@@ -68,10 +69,14 @@ class ProblemDetail(BaseModel):
 
 
 def redact_sensitive(text: str) -> str:
-    """Redacts PII from text before logging."""
-    text = re.sub(r'\b[\w.-]+@[\w.-]+\.\w+\b', '[EMAIL]', text)
-    text = re.sub(r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b', '[IP]', text)
-    return text
+    """Redacts PII/secrets from text before logging or egress.
+
+    Delegates to the shared, fail-closed redactor in
+    :mod:`astradesk_core.redaction` so emails, tokens, secret assignments, API
+    keys, private-key markers, IPs, and card/SSN shapes are all covered by one
+    deterministic boundary (``INV-NO-RAW-EGRESS``).
+    """
+    return redact_text(text)
 
 
 async def is_safe_input(
@@ -80,8 +85,10 @@ async def is_safe_input(
 ) -> bool:
     """Checks if input is safe. Async for policy checks."""
     with tracer.start_as_current_span('guardrails.is_safe_input') as span:
-        span.set_attribute('input_preview', text[:50])
         safe_text = redact_sensitive(text)
+        # Preview is derived from the redacted text and bounded; raw input must
+        # never reach the span (INV-PII-1/INV-PII-4).
+        span.set_attribute('input_preview', safe_preview(text, 50))
         normalized = ' '.join(safe_text.lower().split())
 
         if opa_client:

--- a/services/api-gateway/src/model_gateway/llm_planner.py
+++ b/services/api-gateway/src/model_gateway/llm_planner.py
@@ -23,6 +23,7 @@ import logging
 from collections.abc import Sequence
 from typing import Any
 
+from astradesk_core.redaction import safe_preview
 from opa_client.opa import OpaClient
 from opentelemetry import trace
 
@@ -67,12 +68,23 @@ class LLMPlanner:
         messages: Sequence[LLMMessage | dict[str, str]],
         params: ChatParams | dict[str, Any] | None = None,
     ) -> str:
-        """Delegate normalized chat requests to the currently routed provider."""
+        """Delegate normalized chat requests to the currently routed provider.
+
+        This is the shared model-egress boundary for reflection/scoring calls
+        made across the runtime (agents, orchestrator, RAG). Message content is
+        redacted here so raw user input cannot reach the external model by a
+        call site forgetting to redact (``INV-PII-1``/``INV-PII-4``). Redaction
+        is idempotent, so already-redacted planner prompts are unaffected.
+        """
         normalized_messages = [
             message
             if isinstance(message, LLMMessage)
             else LLMMessage(role=message['role'], content=message['content'])
             for message in messages
+        ]
+        normalized_messages = [
+            LLMMessage(role=message.role, content=redact_sensitive(message.content))
+            for message in normalized_messages
         ]
         normalized_params = (
             params if isinstance(params, ChatParams) else ChatParams.model_validate(params or {})
@@ -84,10 +96,11 @@ class LLMPlanner:
         """Generates validated execution plan with reflection."""
         self._available_tools = list(available_tools)
         with self.tracer.start_as_current_span('llm_planner.make_plan') as span:
-            span.set_attribute('query_preview', query[:100])
-            span.set_attribute('tool_count', len(available_tools))
-
+            # Classify + redact BEFORE any preview reaches the span; the preview
+            # is taken from redacted text, never the raw query (INV-PII-1).
             safe_query = redact_sensitive(query)
+            span.set_attribute('query_preview', safe_preview(query, 100))
+            span.set_attribute('tool_count', len(available_tools))
             if not await is_safe_input(safe_query, self.opa_client):
                 span.add_event('unsafe_input_blocked')
                 return PlanModel(steps=[])
@@ -115,7 +128,9 @@ class LLMPlanner:
                 raw_response = await provider.chat(messages, params=params)
                 plan = await validate_plan_json(raw_response, self.opa_client)
 
-                score = await reflect_plan_quality(plan, query, provider)
+                # Pass the redacted query: reflection prompts go straight to
+                # provider.chat (bypassing the redaction in this.chat).
+                score = await reflect_plan_quality(plan, safe_query, provider)
                 span.set_attribute('reflection_score', score)
 
                 if score < 0.7:

--- a/services/api-gateway/src/model_gateway/providers/openai_provider.py
+++ b/services/api-gateway/src/model_gateway/providers/openai_provider.py
@@ -30,6 +30,7 @@ import os
 from collections.abc import AsyncIterator, Sequence
 
 import httpx
+from astradesk_core.egress import ensure_allowed
 
 from ..base import (
     ChatChunk,
@@ -102,6 +103,9 @@ class OpenAIProvider(LLMProvider):
             )
 
         resolved_base_url = base_url or os.getenv('OPENAI_BASE_URL') or _DEFAULT_OPENAI_BASE_URL
+        # Fail-closed egress governance (INV-PII-3): the model target host must
+        # be on the allow-list. Raises EgressDenied for an unlisted target.
+        ensure_allowed(resolved_base_url, category='model')
         resolved_model = model or os.getenv('OPENAI_MODEL') or _DEFAULT_OPENAI_MODEL
         resolved_timeout = (
             timeout_sec

--- a/services/api-gateway/src/model_gateway/providers/vllm_provider.py
+++ b/services/api-gateway/src/model_gateway/providers/vllm_provider.py
@@ -47,6 +47,7 @@ import os
 from collections.abc import AsyncIterator, Sequence
 
 import httpx
+from astradesk_core.egress import ensure_allowed
 
 from ..base import (
     ChatChunk,
@@ -79,6 +80,9 @@ class VLLMProvider(LLMProvider):
         # Sprawdź, czy VLLM_MODEL jest ustawione
         if not VLLM_MODEL:
             raise ModelGatewayError('VLLM_MODEL environment variable is required', provider='vllm')
+
+        # Fail-closed egress governance (INV-PII-3): deny an unlisted vLLM host.
+        ensure_allowed(VLLM_BASE_URL, category='model')
 
         headers = {}
         if VLLM_API_KEY:

--- a/services/api-gateway/src/runtime/pii.py
+++ b/services/api-gateway/src/runtime/pii.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/src/runtime/pii.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Implements AstraDesk functionality for services/api-gateway/src/runtime/pii.py.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Ingress PII/secret classification and emitter-boundary redaction helpers.
+
+This is the API Gateway-side façade over the shared
+:mod:`astradesk_core.redaction` and :mod:`astradesk_core.egress` boundaries. It
+adds two runtime concerns on top of the pure utilities:
+
+1. **Classification propagation** (``INV-PII-2``): a request's data
+   classification is attached at ingress via a :class:`~contextvars.ContextVar`
+   and is readable by any downstream emitter on the same task.
+2. **Emitter-boundary redaction** (``INV-PII-4``): :func:`set_safe_attribute`
+   is the *only* sanctioned way to put request-derived values onto an OTel span.
+   It redacts before the value can be set, so raw user text can never become a
+   span attribute by call-site omission.
+
+Re-exports the redaction primitives so call sites import a single module.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Any
+
+from astradesk_core.egress import EgressDenied, ensure_allowed, is_allowed
+from astradesk_core.redaction import (
+    REDACTION_FAILED,
+    classify,
+    is_sensitive,
+    redact_mapping,
+    redact_text,
+    redact_value,
+    safe_preview,
+)
+
+__all__ = [
+    'EgressDenied',
+    'REDACTION_FAILED',
+    'attach_classification',
+    'classify',
+    'current_classification',
+    'ensure_allowed',
+    'is_allowed',
+    'is_sensitive',
+    'redact_mapping',
+    'redact_text',
+    'redact_value',
+    'safe_preview',
+    'set_safe_attribute',
+]
+
+# Per-request classification, propagated across the async task via contextvars.
+_classification: ContextVar[frozenset[str]] = ContextVar(
+    'astradesk_pii_classification', default=frozenset()
+)
+
+
+def attach_classification(text: str) -> frozenset[str]:
+    """Classify ingress ``text`` and bind the result to the current context.
+
+    Called once at the request boundary (orchestrator ingress). Returns the
+    detected category set so the caller can also record a redacted summary.
+    """
+    categories = classify(text)
+    _classification.set(categories)
+    return categories
+
+
+def current_classification() -> frozenset[str]:
+    """Return the classification attached for the current request, if any."""
+    return _classification.get()
+
+
+def set_safe_attribute(span: Any, key: str, value: Any) -> None:
+    """Set an OTel span attribute after redacting any request-derived text.
+
+    This is the emitter-boundary choke point for span attributes
+    (``INV-PII-4``). String values are redacted; numeric/boolean values pass
+    through with their native type preserved. Failure to set an attribute must
+    never propagate raw text, so any error is swallowed defensively.
+    """
+    try:
+        safe = redact_value(value)
+        span.set_attribute(key, safe)
+    except Exception:
+        # Telemetry must never raise into the request path nor leak raw text.
+        try:
+            span.set_attribute(key, REDACTION_FAILED)
+        except Exception:
+            pass

--- a/services/api-gateway/src/runtime/rag.py
+++ b/services/api-gateway/src/runtime/rag.py
@@ -36,6 +36,7 @@ import os
 from typing import Any, Protocol
 
 import torch  # PyTorch 2.9 for embeddings and torch.compile
+from astradesk_core.redaction import safe_preview  # Emitter-boundary redaction
 from opa_client.opa import OpaClient  # OPA for governance
 from opentelemetry import trace  # AstraOps/OTel tracing
 from pydantic import BaseModel, ValidationError  # Pydantic v2.9+ for models
@@ -327,7 +328,10 @@ class RAG:
         k = k or self.config.k
 
         with self.tracer.start_as_current_span('rag.retrieve') as span:
-            span.set_attribute('query', query)
+            # The raw query is used in-memory for embedding/BM25, but must be
+            # redacted before it becomes a span attribute (INV-PII-1). RAG
+            # query traces are a named leak surface in ISSUES_NEW-04.
+            span.set_attribute('query_preview', safe_preview(query, 100))
             span.set_attribute('agent_name', agent_name)
             span.set_attribute('k', k)
             span.set_attribute('use_reflection', use_reflection)

--- a/services/api-gateway/src/tools/metrics.py
+++ b/services/api-gateway/src/tools/metrics.py
@@ -31,6 +31,7 @@ import re
 from typing import Final
 
 import httpx
+from astradesk_core.redaction import safe_preview
 from model_gateway.guardrails import ProblemDetail
 from opa_client.opa import OpaClient
 from opentelemetry import trace
@@ -72,7 +73,9 @@ async def _prom_query(
 ) -> float | None:
     """Executes a single PromQL query with tracing."""
     with tracer.start_as_current_span(f'prometheus.query.{metric_name}') as span:
-        span.set_attribute('query', query)
+        # The PromQL string can embed user-influenced fragments; redact before
+        # it reaches the span (INV-PII-1/INV-PII-4).
+        span.set_attribute('query_preview', safe_preview(query, 120))
         span.set_attribute('service', redact_service_name(service))
 
         try:
@@ -99,7 +102,9 @@ async def metrics(
 ) -> str:
     """Fetches service metrics from Prometheus with full governance and observability."""
     with tracer.start_as_current_span('tool.metrics') as span:
-        span.set_attribute('service', service)
+        # Only allow-listed service names are emitted verbatim; anything else
+        # is redacted before reaching the span (shared boundary, INV-PII-4).
+        span.set_attribute('service', redact_service_name(service))
         span.set_attribute('window', window)
 
         if service not in ALLOWED_SERVICES:

--- a/services/api-gateway/src/tools/ops_actions.py
+++ b/services/api-gateway/src/tools/ops_actions.py
@@ -82,7 +82,9 @@ async def restart_service(
 ) -> str:
     """Restarts a Kubernetes Deployment using rollout restart with full governance."""
     with tracer.start_as_current_span('tool.ops.restart_service') as span:
-        span.set_attribute('service', service)
+        # Emit only allow-listed service names verbatim; redact otherwise so an
+        # unexpected/user-influenced value never reaches the span (INV-PII-4).
+        span.set_attribute('service', redact_service_name(service))
         span.set_attribute('namespace', KUBERNETES_NAMESPACE)
 
         logger.info(f"Restart request for service: '{service}'")

--- a/services/api-gateway/src/tools/tickets_proxy.py
+++ b/services/api-gateway/src/tools/tickets_proxy.py
@@ -37,6 +37,7 @@ import uuid
 from typing import Any
 
 import httpx
+from astradesk_core.redaction import safe_preview
 from httpx import ConnectError, ConnectTimeout, HTTPStatusError, PoolTimeout, ReadTimeout
 from model_gateway.guardrails import ProblemDetail
 from opa_client.opa import OpaClient
@@ -91,7 +92,13 @@ def _stub_ticket(title: str, description: str) -> str:
 
 
 def redact_ticket_title(title: str) -> str:
-    return title[:30] + '...' if len(title) > 30 else title
+    """Redact PII/secrets from a ticket title, then bound its length.
+
+    Redaction runs through the shared boundary first (so emails/tokens in a
+    title never reach a span), then the result is truncated for brevity.
+    """
+    redacted = safe_preview(title, 10_000)
+    return redacted[:30] + '...' if len(redacted) > 30 else redacted
 
 
 class TicketsError(Exception):

--- a/services/api-gateway/tests/runtime/test_egress_allowlist.py
+++ b/services/api-gateway/tests/runtime/test_egress_allowlist.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/tests/runtime/test_egress_allowlist.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Verifies AstraDesk behavior for the associated component.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Egress allow-list tests (ISSUES_NEW-04 INV-PII-3; required tests 6 and 7).
+
+Covers the shared allow-list, fail-closed denial of unlisted targets, the
+model-provider construction guard, and environment-driven extension.
+"""
+
+from __future__ import annotations
+
+import pytest
+from astradesk_core import egress
+from astradesk_core.egress import (
+    EgressDenied,
+    ensure_allowed,
+    host_of,
+    is_allowed,
+)
+
+
+def test_default_model_target_allowed() -> None:
+    assert is_allowed('https://api.openai.com/v1') is True
+    assert ensure_allowed('https://api.openai.com/v1', category='model') == 'api.openai.com'
+
+
+def test_unlisted_target_denied() -> None:
+    assert is_allowed('https://evil.attacker.example/v1') is False
+    with pytest.raises(EgressDenied) as exc:
+        ensure_allowed('https://evil.attacker.example/v1', category='model')
+    assert exc.value.code == 'EGRESS_DENIED'
+    assert exc.value.host == 'evil.attacker.example'
+
+
+def test_unparseable_target_is_fail_closed() -> None:
+    # No host → denied (never silently allowed).
+    assert is_allowed('') is False
+    with pytest.raises(EgressDenied):
+        ensure_allowed('', category='sink')
+
+
+def test_host_of_strips_scheme_and_port() -> None:
+    assert host_of('https://kb.test:8443/search') == 'kb.test'
+    assert host_of('kb.test') == 'kb.test'
+    assert host_of('HTTP://API.OpenAI.com') == 'api.openai.com'
+
+
+def test_env_extends_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(egress.ENV_ALLOWLIST, 'kb.allowed.test, extra.host.test')
+    assert is_allowed('https://kb.allowed.test/search') is True
+    assert is_allowed('https://extra.host.test/x') is True
+    # A still-unlisted host remains denied.
+    assert is_allowed('https://nope.test') is False
+
+
+def test_egress_denied_message_has_no_payload() -> None:
+    # The error must not carry payload/secret material, only host + category.
+    err = EgressDenied('evil.example', 'model')
+    text = str(err)
+    assert 'evil.example' in text
+    assert 'model' in text
+    assert 'token' not in text.lower()
+
+
+def test_openai_provider_denied_for_unlisted_base_url() -> None:
+    from model_gateway.providers.openai_provider import OpenAIProvider
+
+    with pytest.raises(EgressDenied):
+        OpenAIProvider(api_key='test-key', base_url='https://evil.attacker.example/v1')
+
+
+def test_openai_provider_allowed_for_listed_base_url() -> None:
+    from model_gateway.providers.openai_provider import OpenAIProvider
+
+    # Default api.openai.com host is allow-listed; construction must succeed.
+    provider = OpenAIProvider(api_key='test-key', base_url='https://api.openai.com/v1')
+    assert provider is not None

--- a/services/api-gateway/tests/runtime/test_pii_emitters.py
+++ b/services/api-gateway/tests/runtime/test_pii_emitters.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/tests/runtime/test_pii_emitters.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Verifies AstraDesk behavior for the associated component.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Emitter-boundary redaction tests (ISSUES_NEW-04 required tests 4, 5, 6).
+
+These exercise the actual high-risk emitters with a recording span/tracer so we
+assert raw user input never reaches a span attribute or a model payload.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from runtime.pii import set_safe_attribute
+
+_RAW_EMAIL = 'victim@example.com'
+_RAW_TOKEN = 'Bearer aaa.bbb.ccc'
+
+
+class _RecordingSpan:
+    """Minimal OTel span stand-in that records attributes/events."""
+
+    def __init__(self, name: str, store: dict[str, dict[str, Any]]) -> None:
+        self._name = name
+        self._store = store
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        self._store.setdefault(self._name, {})[key] = value
+
+    def add_event(self, *_a: Any, **_k: Any) -> None:
+        pass
+
+    def record_exception(self, *_a: Any, **_k: Any) -> None:
+        pass
+
+    def __enter__(self) -> _RecordingSpan:
+        return self
+
+    def __exit__(self, *_a: Any) -> bool:
+        return False
+
+
+class _RecordingTracer:
+    def __init__(self) -> None:
+        self.spans: dict[str, dict[str, Any]] = {}
+
+    def start_as_current_span(self, name: str, *_a: Any, **_k: Any) -> _RecordingSpan:
+        return _RecordingSpan(name, self.spans)
+
+
+def _all_attr_values(spans: dict[str, dict[str, Any]]) -> str:
+    blob: list[str] = []
+    for attrs in spans.values():
+        for value in attrs.values():
+            blob.append(str(value))
+    return '\n'.join(blob)
+
+
+def test_set_safe_attribute_redacts_and_preserves_scalars() -> None:
+    store: dict[str, dict[str, Any]] = {}
+    span = _RecordingSpan('s', store)
+    set_safe_attribute(span, 'q', f'mail {_RAW_EMAIL}')
+    set_safe_attribute(span, 'count', 5)
+    assert _RAW_EMAIL not in str(store['s']['q'])
+    assert store['s']['count'] == 5
+
+
+@pytest.mark.asyncio
+async def test_guardrails_input_preview_is_redacted(monkeypatch: pytest.MonkeyPatch) -> None:
+    from model_gateway import guardrails
+
+    tracer = _RecordingTracer()
+    monkeypatch.setattr(guardrails, 'tracer', tracer)
+
+    await guardrails.is_safe_input(f'please refund {_RAW_EMAIL} now')
+
+    span_attrs = tracer.spans['guardrails.is_safe_input']
+    assert _RAW_EMAIL not in str(span_attrs['input_preview'])
+    assert '[REDACTED_EMAIL]' in str(span_attrs['input_preview'])
+
+
+@pytest.mark.asyncio
+async def test_rag_query_span_is_redacted(monkeypatch: pytest.MonkeyPatch) -> None:
+    from runtime import rag as rag_module
+
+    # Build a RAG instance without loading the heavy embedding model / torch.
+    monkeypatch.setattr(rag_module, 'SentenceTransformer', lambda *_a, **_k: MagicMock())
+    fake_torch = MagicMock()
+    fake_torch.cuda.is_available.return_value = False
+    fake_torch.device.return_value = MagicMock(type='cpu')
+    monkeypatch.setattr(rag_module, 'torch', fake_torch)
+
+    instance = rag_module.RAG(config=rag_module.RAGConfig(use_fp16=False))
+    tracer = _RecordingTracer()
+    instance.tracer = tracer
+    instance.opa_client = None
+    instance.llm_planner = None
+    instance.bm25 = None
+    instance.keyword_index = []
+    instance.pg_pool = None
+    # Model encode returns a vector regardless of input.
+    encoded = MagicMock()
+    encoded.cpu.return_value.tolist.return_value = [0.1, 0.2, 0.3]
+    instance.model = MagicMock()
+    instance.model.encode.return_value = encoded
+
+    result = await instance.retrieve(
+        query=f'reset password for {_RAW_EMAIL}',
+        agent_name='support',
+        use_reflection=False,
+    )
+
+    assert result == []
+    blob = _all_attr_values(tracer.spans)
+    assert _RAW_EMAIL not in blob
+    assert 'query_preview' in tracer.spans['rag.retrieve']
+
+
+@pytest.mark.asyncio
+async def test_llm_planner_chat_redacts_model_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    from model_gateway import llm_planner as planner_module
+    from model_gateway.base import ChatParams, LLMMessage
+
+    sent: dict[str, list[LLMMessage]] = {}
+
+    class _FakeProvider:
+        async def chat(self, messages: list[LLMMessage], params: ChatParams | None = None) -> str:
+            sent['messages'] = list(messages)
+            return 'ok'
+
+    async def _get_provider() -> _FakeProvider:
+        return _FakeProvider()
+
+    monkeypatch.setattr(planner_module.provider_router, 'get_provider', _get_provider)
+
+    planner = planner_module.LLMPlanner()
+    out = await planner.chat(
+        [{'role': 'user', 'content': f'contact {_RAW_EMAIL} with {_RAW_TOKEN}'}]
+    )
+    assert out == 'ok'
+
+    payload = '\n'.join(m.content for m in sent['messages'])
+    assert _RAW_EMAIL not in payload
+    assert 'aaa.bbb.ccc' not in payload
+    assert '[REDACTED_EMAIL]' in payload
+    assert '[REDACTED_TOKEN]' in payload

--- a/services/api-gateway/tests/runtime/test_pii_emitters.py
+++ b/services/api-gateway/tests/runtime/test_pii_emitters.py
@@ -21,7 +21,7 @@ assert raw user input never reaches a span attribute or a model payload.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 from unittest.mock import MagicMock
 
 import pytest
@@ -50,7 +50,7 @@ class _RecordingSpan:
     def __enter__(self) -> _RecordingSpan:
         return self
 
-    def __exit__(self, *_a: Any) -> bool:
+    def __exit__(self, *_a: Any) -> Literal[False]:
         return False
 
 

--- a/services/api-gateway/tests/runtime/test_pii_redaction.py
+++ b/services/api-gateway/tests/runtime/test_pii_redaction.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/tests/runtime/test_pii_redaction.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Verifies AstraDesk behavior for the associated component.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Unit + leak-corpus tests for the shared PII/secret redaction boundary.
+
+Covers ISSUES_NEW-04 required tests 1, 2, 3, 9, and 10. To avoid logging raw
+samples in failure messages (per the issue guidance), assertions use a custom
+message that names only the placeholder/category, never the secret value.
+"""
+
+from __future__ import annotations
+
+import pytest
+from astradesk_core import redaction
+from astradesk_core.redaction import (
+    PLACEHOLDER_EMAIL,
+    PLACEHOLDER_PRIVATE_KEY,
+    PLACEHOLDER_SECRET,
+    PLACEHOLDER_TOKEN,
+    REDACTION_FAILED,
+    classify,
+    redact_mapping,
+    redact_text,
+    safe_preview,
+)
+from runtime import pii
+
+# A representative leak corpus: (secret_fragment, raw_input, expected_placeholder).
+# secret_fragment is the substring that MUST NOT survive redaction.
+_LEAK_CORPUS = [
+    ('alice@example.com', 'Please email alice@example.com today', PLACEHOLDER_EMAIL),
+    (
+        'sk-ABCDEF0123456789ABCDEF',
+        'my key is sk-ABCDEF0123456789ABCDEF ok',
+        PLACEHOLDER_TOKEN,
+    ),
+    (
+        'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345',
+        'token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345',
+        PLACEHOLDER_TOKEN,
+    ),
+    (
+        'eyJhbGci.eyJzdWIi.SflKxwRJ',
+        'Authorization header eyJhbGci.eyJzdWIi.SflKxwRJ value',
+        PLACEHOLDER_TOKEN,
+    ),
+    ('hunter2secret', 'password=hunter2secret', PLACEHOLDER_SECRET),
+    ('topsecretval', 'api_key: topsecretval', PLACEHOLDER_SECRET),
+    ('AKIAIOSFODNN7EXAMPLE', 'aws AKIAIOSFODNN7EXAMPLE creds', PLACEHOLDER_TOKEN),
+]
+
+
+def _assert_absent(fragment: str, text: str, label: str) -> None:
+    # Never echo the raw fragment into the assertion message.
+    assert fragment not in text, f'raw {label} survived redaction'
+
+
+@pytest.mark.parametrize('fragment,raw,placeholder', _LEAK_CORPUS)
+def test_leak_corpus_redacted(fragment: str, raw: str, placeholder: str) -> None:
+    redacted = redact_text(raw)
+    _assert_absent(fragment, redacted, 'value')
+    assert placeholder in redacted
+
+
+def test_email_redaction() -> None:
+    out = redact_text('contact bob@corp.example for help')
+    assert 'bob@corp.example' not in out
+    assert PLACEHOLDER_EMAIL in out
+
+
+def test_bearer_token_redaction() -> None:
+    out = redact_text('Authorization: Bearer abcdef.ghijkl.mnopqr')
+    assert 'abcdef.ghijkl.mnopqr' not in out
+    assert PLACEHOLDER_TOKEN in out
+    # Scheme word may remain; the credential must not.
+    assert 'Bearer' in out
+
+
+def test_private_key_marker_redaction() -> None:
+    pem = (
+        '-----BEGIN RSA PRIVATE KEY-----\n'
+        'MIIEowIBAAKCAQEA1234567890abcdef\n'
+        '-----END RSA PRIVATE KEY-----'
+    )
+    out = redact_text(f'leaked key:\n{pem}')
+    assert 'MIIEowIBAAKCAQEA1234567890abcdef' not in out
+    assert PLACEHOLDER_PRIVATE_KEY in out
+
+
+def test_private_key_bare_marker_redaction() -> None:
+    out = redact_text('header -----BEGIN OPENSSH PRIVATE KEY----- truncated')
+    assert '-----BEGIN OPENSSH PRIVATE KEY-----' not in out
+    assert PLACEHOLDER_PRIVATE_KEY in out
+
+
+def test_classification_detects_categories() -> None:
+    categories = classify('email me@x.io and password=swordfish99')
+    assert 'email' in categories
+    assert 'secret' in categories
+
+
+def test_classification_empty_for_benign_text() -> None:
+    assert classify('restart the webapp service please') == frozenset()
+
+
+def test_safe_preview_redacts_before_truncation() -> None:
+    raw = 'urgent: alice@example.com needs a refund right away please respond'
+    preview = safe_preview(raw, 40)
+    assert 'alice@example.com' not in preview
+    assert len(preview) <= 40
+
+
+def test_redactor_failure_is_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Force the internal pipeline to raise; the redactor must NOT return raw.
+    class _ExplodingPattern:
+        def sub(self, *_a: object, **_k: object) -> str:
+            raise RuntimeError('detector exploded')
+
+    monkeypatch.setattr(
+        redaction,
+        '_PIPELINE',
+        (('email', _ExplodingPattern(), 'X'),),
+    )
+    out = redact_text('secret alice@example.com value')
+    assert out == REDACTION_FAILED
+    assert 'alice@example.com' not in out
+
+
+def test_redact_mapping_scrubs_string_values() -> None:
+    data = {
+        'title': 'reset password for bob@corp.example',
+        'count': 3,
+        'nested': {'token': 'Bearer zzz.yyy.xxx'},
+        'tags': ['ok', 'mail me@x.io'],
+    }
+    out = redact_mapping(data)
+    assert 'bob@corp.example' not in str(out)
+    assert 'zzz.yyy.xxx' not in str(out)
+    assert 'me@x.io' not in str(out)
+    assert out['count'] == 3  # non-string scalar preserved
+
+
+def test_runtime_pii_reexports_and_classification_contextvar() -> None:
+    # attach_classification binds to the contextvar; current reads it back.
+    categories = pii.attach_classification('ping ops@x.io')
+    assert 'email' in categories
+    assert pii.current_classification() == categories
+    # Re-export parity.
+    assert pii.redact_text('a@b.co') == redact_text('a@b.co')

--- a/services/api-gateway/tests/runtime/test_span_redaction_guard.py
+++ b/services/api-gateway/tests/runtime/test_span_redaction_guard.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/tests/runtime/test_span_redaction_guard.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Verifies AstraDesk behavior for the associated component.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Static regression guard (ISSUES_NEW-04 required test 11).
+
+Fails if any of the changed high-risk emitter surfaces sets raw user text as a
+span attribute. This enforces INV-PII-4 (redaction at the emitter, not as an
+optional call-site habit) and catches regressions where a developer reintroduces
+``span.set_attribute('query', query)`` instead of ``safe_preview(query, ...)``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_SRC = _REPO_ROOT / 'services' / 'api-gateway' / 'src'
+
+# High-risk emitter surfaces named in the issue contract.
+_GUARDED_FILES = [
+    _SRC / 'model_gateway' / 'guardrails.py',
+    _SRC / 'model_gateway' / 'llm_planner.py',
+    _SRC / 'runtime' / 'rag.py',
+    _SRC / 'agents' / 'base.py',
+    _SRC / 'agents' / 'support.py',
+    _SRC / 'agents' / 'ops.py',
+    _SRC / 'gateway' / 'orchestrator.py',
+    _SRC / 'tools' / 'metrics.py',
+    _SRC / 'tools' / 'ops_actions.py',
+]
+
+# Span attribute keys that historically carried raw user text. The 'query' and
+# 'input' keys must not be used at all; the *_preview keys must be fed redacted.
+_RAW_KEY_RE = re.compile(r"""set_attribute\(\s*(['"])(query|input)\1\s*,""")
+_PREVIEW_KEY_RE = re.compile(
+    r"""set_attribute\(\s*['"](query_preview|input_preview)['"]\s*,\s*(?P<value>[^)]*)\)"""
+)
+# A redacted value must route through one of these helpers.
+_SAFE_MARKERS = ('safe_preview', 'redact', 'redact_service_name')
+
+
+@pytest.mark.parametrize('path', _GUARDED_FILES, ids=lambda p: p.name)
+def test_no_raw_user_text_span_attribute(path: Path) -> None:
+    assert path.is_file(), f'guarded file missing: {path}'
+    source = path.read_text(encoding='utf-8')
+
+    # 1. No raw 'query'/'input' span keys remain.
+    assert (
+        _RAW_KEY_RE.search(source) is None
+    ), f'{path.name}: raw span attribute key set without redaction'
+
+    # 2. Every *_preview span attribute value is produced by a safe helper.
+    for match in _PREVIEW_KEY_RE.finditer(source):
+        value = match.group('value')
+        assert any(
+            marker in value for marker in _SAFE_MARKERS
+        ), f'{path.name}: preview span attribute set without a redaction helper'
+
+
+def test_guard_actually_inspected_files() -> None:
+    # Sanity: the corpus is non-empty and the files contain set_attribute calls,
+    # so the guard cannot silently pass on an empty/renamed tree.
+    assert _GUARDED_FILES
+    assert any('set_attribute' in p.read_text(encoding='utf-8') for p in _GUARDED_FILES)


### PR DESCRIPTION
Summary

Implements ISSUE NEW-04: ingress PII/secret redaction and fail-closed egress boundary.

What changed

- Added shared deterministic redaction and classification in core.
- Added shared fail-closed egress allow-list in core.
- Added API Gateway runtime PII helper for safe span attributes and classification propagation.
- Replaced raw query/span emissions with redacted safe previews.
- Redacted guardrail, planner, RAG, agent, tool, and model-egress high-risk surfaces.
- Replaced MCP no-op PII middleware with real request classification/redaction behavior.
- Added egress checks for model/provider and MCP KB client paths.
- Added zero-leak regression tests and static/focused span redaction guard.

Verification

- git diff --check: OK
- git diff --name-only --diff-filter=U: OK
- uv run ruff check core/src services/api-gateway/src services/api-gateway/tests mcp/src mcp/tests: OK
- uv run ruff format --check core/src services/api-gateway/src services/api-gateway/tests mcp/src mcp/tests: 83 files already formatted
- NEW-04 targeted tests: 45 passed
- uv run pytest -q services/api-gateway/tests mcp/tests: 323 passed
- uv run pytest -q --cov-report=xml:coverage.xml: 342 passed, 2 warnings
- uv run python scripts/license_headers.py --check: OK
- uv run mypy on changed/new PII and egress surfaces: Success, no issues found in 8 source files

Scope

Not changed:

- RBAC #016
- OIDC/JWKS verification #009
- durable audit #019
- OPA/schema-hash #028
- Admin API contract / OpenAPI
- Java ticket adapter internals

Design note

LLMPlanner.chat redacts message content at the model-egress boundary. This keeps external model calls inside the NEW-04 contract: no raw PII/secrets leave the gateway without redaction and allow-list enforcement.
