### PR TITLE
Add durable side-effect audit trail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,16 @@ ROOT_CA=/etc/istio/certs/ca-cert.pem
 # Optional integrations exposed through API tools.
 WEATHER_API_KEY=
 
+# Durable audit sink for side-effecting (write/execute) tool calls (ISSUE 019).
+# Append-only JSON-Lines file path. On ENVIRONMENT in {production, prod,
+# staging, stage} (ENVIRONMENT defaults to "production" when unset, matching
+# the OIDC fail-closed default) this is REQUIRED: startup aborts with
+# AuditConfigError if it is missing, so a deployed tier can never silently run
+# without a durable audit trail. Outside a deployed tier (e.g. ENVIRONMENT=dev
+# for local/CI), leaving this unset falls back to a non-durable in-process
+# writer with a startup warning — fine for tests/dev, never for production.
+AUDIT_LOG_PATH=
+
 # --- LLM Provider Configuration (services/api-gateway/model_gateway) ---
 OPENAI_API_KEY=
 OPENAI_BASE_URL=https://api.openai.com/v1

--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ make setup
 - **OIDC_ISSUER**: OIDC issuer (e.g. `https://your-issuer.com/`).
 - **OIDC_AUDIENCE**: JWT audience.
 - **OIDC_JWKS_URL**: JWKS URL (e.g. `https://your-issuer.com/.well-known/jwks.json`).
+- **AUDIT_LOG_PATH**: append-only JSON-Lines path for the durable side-effect tool audit trail (ISSUE 019). **Required** when `ENVIRONMENT` is a deployed tier (`production`/`prod`/`staging`/`stage` — `ENVIRONMENT` defaults to `production` when unset): the gateway refuses to start without it (`AuditConfigError`). Outside a deployed tier (e.g. local dev/tests with `ENVIRONMENT=dev`), leaving it unset falls back to a non-durable in-process writer with a startup warning.
 
 Full list in `.env.example`.
 
@@ -1073,7 +1074,7 @@ symlink to the canonical spec so the UI never drifts.
 - **Auth**: OIDC/JWT with JWKS.
 - **RBAC**: Per tool, based on claims.
 - **mTLS**: STRICT via Istio.
-- **Audit**: Logged to Postgres + NATS publish.
+- **Audit**: Logged to Postgres + NATS publish. Every `write`/`execute` tool attempt (allowed, denied, or errored) is additionally recorded through a durable `AuditWriter` at the `ToolRegistry.execute` choke point, on both the LLM-planned and keyword-fallback paths. Deployed tiers (`production`/`prod`/`staging`/`stage`) fail closed at startup without `AUDIT_LOG_PATH`; local/dev/test may fall back to a non-durable in-process writer.
 - **Policies**: Allow-lists in tools, proxy retries.
 
 ## Roadmap

--- a/docs/api.md
+++ b/docs/api.md
@@ -252,6 +252,7 @@ Odpowiedź:
 
 * **Readiness (503):** podczas startu API może zwrócić `503` do czasu inicjalizacji połączeń (Postgres/Redis/RAG/Registry).
 * **Audyt:** każde wywołanie agenta jest logowane (Postgres) i emitowane jako event (NATS) — zapis do S3/Elastic realizuje subskrybent „auditor”.
+* **Audyt narzędzi side-effect (ISSUE 019):** każda próba wywołania narzędzia `write`/`execute` przez `ToolRegistry.execute` — dozwolona, odrzucona przez RBAC lub zakończona błędem — jest trwale zapisywana przez skonfigurowany `AuditWriter` (`services/api-gateway/src/runtime/audit.py`), niezależnie od tego, czy krok pochodzi z planera LLM czy ścieżki fallback. Podgląd argumentów jest redagowany współdzielonym mechanizmem NEW-04. Ustawienie `AUDIT_LOG_PATH` włącza trwały zapis do pliku JSON-Lines. **Na wdrożonych warstwach** (`ENVIRONMENT` ∈ `production`/`prod`/`staging`/`stage`; `production` jest wartością domyślną, gdy `ENVIRONMENT` nie jest ustawione) brak `AUDIT_LOG_PATH` przerywa start serwisu (`AuditConfigError`) — audyt nie może po cichu spaść do trybu nietrwałego. Poza warstwami wdrożeniowymi (np. lokalny dev/test z `ENVIRONMENT=dev`) writer in-proces jest dozwolony, z ostrzeżeniem w logu.
 * **Rate limiting:** (opcjonalnie) może zwrócić `429` z nagłówkiem `Retry-After`.
 * **Observability:** zalecane OTel + Prometheus/Grafana, logi w Loki; `reasoning_trace_id` umożliwia korelację.
 

--- a/services/api-gateway/src/gateway/main.py
+++ b/services/api-gateway/src/gateway/main.py
@@ -47,6 +47,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
 from model_gateway.llm_planner import LLMPlanner
 from model_gateway.router import provider_router
 from opa_client.opa import OpaClient
+from runtime.audit import AuditWriter, FileAuditWriter, InMemoryAuditWriter
 from runtime.authz import SideEffect, enforce_registration_invariants
 from runtime.memory import Memory
 from runtime.models import AgentRequest, AgentResponse
@@ -82,6 +83,52 @@ OPA_URL = os.getenv('OPA_URL', 'http://localhost:8181')
 app_state: dict[str, Any] = {}
 
 
+class AuditConfigError(RuntimeError):
+    """Raised at startup when a deployed tier lacks a durable audit sink.
+
+    Mirrors :class:`astradesk_core.utils.oidc.AuthConfigError`: absence of a
+    required security/evidence dependency must abort startup, not silently
+    downgrade to a weaker mode (``INV-FAIL-CLOSED`` / ``INV-LOCAL-MODE-EXPLICIT``,
+    ISSUE 019).
+    """
+
+
+# Tiers considered "deployed" for the audit fail-closed check below — the same
+# values as astradesk_core.utils.oidc's deployed-tier check, kept local rather
+# than importing that module's private constant for an unrelated concern.
+_AUDIT_DEPLOYED_TIERS = frozenset({'production', 'prod', 'staging', 'stage'})
+
+
+def _resolve_audit_writer() -> AuditWriter:
+    """Select the durable audit sink for side-effecting tools (ISSUE 019).
+
+    ``AUDIT_LOG_PATH`` set: always used — an append-only JSON-Lines file,
+    regardless of tier. Unset: allowed only outside a deployed tier.
+    ``ENVIRONMENT`` defaults to ``'production'`` when unset, the same
+    fail-closed default used by
+    :func:`astradesk_core.utils.oidc.build_verifier_from_env`, so a deployed
+    environment can never silently start with a non-durable sink for
+    ``write``/``execute`` tools — it aborts startup instead
+    (``INV-AUDIT-5``/``INV-FAIL-CLOSED``). The error message names only the
+    tier and the missing variable, never a secret.
+    """
+    audit_log_path = os.getenv('AUDIT_LOG_PATH', '').strip()
+    if audit_log_path:
+        return FileAuditWriter(audit_log_path)
+
+    environment = os.getenv('ENVIRONMENT', 'production').strip().lower()
+    if environment in _AUDIT_DEPLOYED_TIERS:
+        raise AuditConfigError(
+            f"AUDIT_LOG_PATH is required on tier '{environment}': refusing to "
+            'start without a durable audit sink for write/execute tools.'
+        )
+    logger.warning(
+        'AUDIT_LOG_PATH not set; using in-process audit writer '
+        '(events do not survive a restart). Do not use this in production.'
+    )
+    return InMemoryAuditWriter()
+
+
 # --- Application Lifespan (Startup/Shutdown) ---
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
@@ -90,6 +137,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """
     logger.info('API Gateway starting up...')
     install_verifier(app)
+    # Fail-closed before any external resource is touched (ISSUE 019): a
+    # deployed tier without a durable audit sink must never start, mirroring
+    # how the OIDC verifier above already aborts before DB/Redis are touched.
+    audit_writer = _resolve_audit_writer()
 
     # --- Initialize connections ---
     # DATABASE_URL/REDIS_URL always resolve (to real values or safe dummy
@@ -108,7 +159,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     opa_client = OpaClient(url=OPA_URL)
 
     # --- Initialize core components ---
-    tool_registry = ToolRegistry()
+    # audit_writer was already resolved fail-closed above, before any
+    # external resource was touched.
+    tool_registry = ToolRegistry(audit_writer=audit_writer)
     # Register built-in tools with mandatory RBAC metadata (ISSUE 016).
     # side_effect + allowed_roles are the source of truth for the choke point;
     # the OIDC layer normalizes identity/roles, RBAC authorizes from those roles.

--- a/services/api-gateway/src/runtime/audit.py
+++ b/services/api-gateway/src/runtime/audit.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/src/runtime/audit.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Implements AstraDesk functionality for services/api-gateway/src/runtime/audit.py.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Durable audit trail for side-effecting tool execution (ISSUE 019).
+
+This module defines the typed audit event schema and the writer abstraction
+used by :meth:`runtime.registry.ToolRegistry.execute` — the single RBAC choke
+point (ISSUE 016) — to record every attempted ``write``/``execute`` tool call.
+Audit emission is a property of the invocation, not of the code path that
+produced it: the same call in ``ToolRegistry.execute`` is reached by both the
+LLM-planned and keyword-fallback paths (``INV-DUAL-PATH``), so wiring it here
+makes every side-effect attempt auditable regardless of caller.
+
+Target invariants (ISSUE 019)
+------------------------------
+- ``INV-AUDIT-1``: every attempted ``write``/``execute`` tool call emits a
+  durable audit event.
+- ``INV-AUDIT-2``: events are emitted for both allowed and denied attempts.
+- ``INV-AUDIT-3``: events contain only redacted/safe fields — no raw user
+  input, secrets, tokens, credentials, private keys, or raw claims. Argument
+  previews are built through the shared NEW-04 redaction boundary
+  (:mod:`astradesk_core.redaction`), never a second, incompatible redactor.
+- ``INV-AUDIT-4``: events carry correlation data for incident review
+  (``event_id``, ``timestamp``, ``trace_id``, ``request_id``, ``tenant_id``,
+  ``principal_id``, normalized ``roles``, ``tool``, ``side_effect``,
+  ``decision``, denial ``reason``, ``approval_id``, redacted args preview).
+- ``INV-AUDIT-5``: audit failure fails closed for ``write``/``execute`` tools
+  — see :class:`AuditWriteError` and the choke-point wiring in
+  :mod:`runtime.registry`.
+- ``INV-AUDIT-6``: audit is never attempted for ``read`` tools, so a broken
+  writer can never block a read (enforced at the call site, not here).
+- ``INV-AUDIT-7``: events are deterministic for tests — ``event_id``/clock are
+  injectable via :class:`ToolRegistry`'s constructor parameters.
+
+Durability strategy
+--------------------
+:class:`AuditWriter` is a minimal structural protocol (``async def
+write(event)``). Two concrete implementations are provided:
+
+- :class:`InMemoryAuditWriter` — deterministic, dependency-free; the default
+  writer so existing callers/tests keep working unchanged, and useful for
+  introspection in tests.
+- :class:`FileAuditWriter` — append-only JSON-Lines sink that survives process
+  restarts on the same host; the safe local/production durable mode requested
+  by the issue when no external broker is configured.
+
+A NATS-backed writer is intentionally **not** provided here. The only NATS
+publisher currently wired into this codebase
+(:mod:`astradesk_core.utils.events`) is an in-memory test stub (a dummy client
+that discards every publish), not a real broker connection — wrapping it in an
+``AuditWriter`` would produce exactly the misleading, silently-lossy artifact
+this issue exists to remove. Real NATS/JetStream durability for the audit
+pipeline is the scope of the auditor-service rescope tracked in
+``docs/roadmap/issues/ISSUES_019_durable_audit.md`` and is out of scope here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from astradesk_core.redaction import redact_mapping, safe_preview
+
+from runtime.authz import APPROVAL_FIELDS, SideEffect
+
+__all__ = [
+    'AuditDecision',
+    'AuditEvent',
+    'AuditWriteError',
+    'AuditWriter',
+    'ClockFn',
+    'EventIdFn',
+    'FileAuditWriter',
+    'InMemoryAuditWriter',
+    'build_args_preview',
+    'default_clock',
+    'default_event_id',
+    'principal_from_claims',
+    'tenant_from_claims',
+]
+
+logger = logging.getLogger(__name__)
+
+# Bounds for the redacted argument preview (``INV-AUDIT-3``): a preview, never
+# the full payload.
+_ARGS_PREVIEW_MAX_KEYS = 20
+_ARGS_PREVIEW_MAX_CHARS = 200
+_PRINCIPAL_PREVIEW_MAX_CHARS = 100
+
+# Meta kwargs carrying raw claims / approval identifiers. These are never
+# echoed into the argument preview as a container; the audit layer instead
+# surfaces safe, dedicated fields (``principal_id``, ``tenant_id``,
+# ``approval_id``) derived from them.
+_AUDIT_META_KEYS: frozenset[str] = frozenset({'claims', *APPROVAL_FIELDS})
+
+
+class AuditDecision(str, Enum):
+    """Final outcome recorded on an audit event."""
+
+    ALLOWED = 'allowed'
+    DENIED = 'denied'
+    ERROR = 'error'
+
+
+class AuditWriteError(RuntimeError):
+    """Fail-closed signal: a durable audit record could not be written.
+
+    Raised by the ``ToolRegistry.execute`` choke point for ``write``/
+    ``execute`` tools when the configured :class:`AuditWriter` raises
+    (``INV-AUDIT-5``). The underlying tool function must not run once this is
+    raised. The message intentionally carries only the tool name and a stable
+    reason code — never the writer's raw exception text, which could
+    theoretically echo the event payload back.
+    """
+
+    code = 'AUDIT_SINK_UNAVAILABLE'
+
+    def __init__(self, tool: str) -> None:
+        self.tool = tool
+        super().__init__(f"{self.code}: audit sink unavailable for tool '{tool}'")
+
+
+@dataclass(frozen=True, slots=True)
+class AuditEvent:
+    """Durable, structured record of one attempted tool invocation.
+
+    Every field is either a stable identifier, a policy-configuration value
+    (tool name, roles, reason code), or a value that has already passed
+    through the shared redaction boundary. Nothing here may carry raw user
+    input, secrets, tokens, credentials, private keys, or raw claims
+    (``INV-AUDIT-3``).
+    """
+
+    event_id: str
+    timestamp: datetime
+    tool: str
+    side_effect: SideEffect
+    decision: AuditDecision
+    roles: tuple[str, ...] = ()
+    trace_id: str | None = None
+    request_id: str | None = None
+    tenant_id: str | None = None
+    principal_id: str | None = None
+    reason: str | None = None
+    approval_id: str | None = None
+    args_preview: dict[str, Any] = field(default_factory=dict)
+    error_type: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation (stable key order)."""
+        return {
+            'event_id': self.event_id,
+            'timestamp': self.timestamp.isoformat(),
+            'tool': self.tool,
+            'side_effect': self.side_effect.value,
+            'decision': self.decision.value,
+            'roles': list(self.roles),
+            'trace_id': self.trace_id,
+            'request_id': self.request_id,
+            'tenant_id': self.tenant_id,
+            'principal_id': self.principal_id,
+            'reason': self.reason,
+            'approval_id': self.approval_id,
+            'args_preview': self.args_preview,
+            'error_type': self.error_type,
+        }
+
+
+@runtime_checkable
+class AuditWriter(Protocol):
+    """Structural contract for a durable(-compatible) audit sink."""
+
+    async def write(self, event: AuditEvent) -> None:
+        """Persist ``event``. Must raise on failure — never swallow silently."""
+        ...
+
+
+class InMemoryAuditWriter:
+    """Deterministic, dependency-free writer; the default for ``ToolRegistry``.
+
+    Never raises, so it never changes existing RBAC (#016) behavior for
+    callers that do not configure an explicit durable sink. Recorded events
+    are readable via :attr:`events`, which makes it the natural writer for
+    unit tests as well.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[AuditEvent] = []
+        self._lock = asyncio.Lock()
+
+    async def write(self, event: AuditEvent) -> None:
+        async with self._lock:
+            self.events.append(event)
+
+
+class FileAuditWriter:
+    """Append-only JSON-Lines audit sink that survives process restarts.
+
+    The safe, explicit local/production durable mode (``INV-LOCAL-MODE-EXPLICIT``
+    counterpart for audit): a developer or operator opts in by pointing
+    ``AUDIT_LOG_PATH`` at a writable file. Each event is one JSON line, written
+    with the shared redaction boundary already applied by the caller
+    (:class:`AuditEvent` fields are safe by construction).
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = asyncio.Lock()
+
+    async def write(self, event: AuditEvent) -> None:
+        import json
+
+        line = json.dumps(
+            event.to_dict(), ensure_ascii=False, separators=(',', ':'), sort_keys=True
+        )
+        async with self._lock:
+            await asyncio.to_thread(self._append_line, line)
+
+    def _append_line(self, line: str) -> None:
+        with self._path.open('a', encoding='utf-8') as fh:
+            fh.write(line + '\n')
+
+
+EventIdFn = Callable[[], str]
+ClockFn = Callable[[], datetime]
+
+
+def default_event_id() -> str:
+    """Generate a unique, non-guessable audit event id."""
+    return f'audit-{uuid.uuid4()}'
+
+
+def default_clock() -> datetime:
+    """Return the current UTC time (timezone-aware, per ``INV-AUDIT-7``)."""
+    return datetime.now(UTC)
+
+
+def _bound(value: object) -> object:
+    """Recursively bound a redacted value for a safe, size-limited preview."""
+    if isinstance(value, str):
+        if len(value) <= _ARGS_PREVIEW_MAX_CHARS:
+            return value
+        return value[:_ARGS_PREVIEW_MAX_CHARS] + '…'
+    if isinstance(value, Mapping):
+        return {k: _bound(v) for k, v in list(value.items())[:_ARGS_PREVIEW_MAX_KEYS]}
+    if isinstance(value, list | tuple):
+        return [_bound(v) for v in list(value)[:_ARGS_PREVIEW_MAX_KEYS]]
+    if value is None or isinstance(value, bool | int | float):
+        return value
+    return _bound(str(value))
+
+
+def build_args_preview(kwargs: Mapping[str, Any]) -> dict[str, Any]:
+    """Build a bounded, redacted preview of tool invocation arguments.
+
+    Meta kwargs (``claims`` and the approval-id field names) are dropped
+    entirely rather than redacted-in-place: they are raw-claim containers, not
+    business arguments, and are surfaced instead through the dedicated
+    ``principal_id``/``tenant_id``/``approval_id`` fields on
+    :class:`AuditEvent`. Everything else is passed through the shared NEW-04
+    redaction boundary and then size-bounded. Fail-closed on internal error:
+    never the raw arguments.
+    """
+    business = {k: v for k, v in kwargs.items() if k not in _AUDIT_META_KEYS}
+    try:
+        redacted = redact_mapping(business)
+    except Exception:  # pragma: no cover - redact_mapping already fails closed
+        return {'_redaction': 'REDACTION_FAILED'}
+
+    bounded: dict[str, Any] = {}
+    for i, (key, value) in enumerate(redacted.items()):
+        if i >= _ARGS_PREVIEW_MAX_KEYS:
+            bounded['_truncated'] = True
+            break
+        bounded[key] = _bound(value)
+    return bounded
+
+
+def principal_from_claims(claims: Mapping[str, Any] | None) -> str | None:
+    """Derive a safe subject identifier from verified claims, if present.
+
+    Reads the standard OIDC ``sub`` claim only and passes it through the
+    shared redaction/bounding helper — defense in depth in case an IdP ever
+    puts an email-shaped value in ``sub``. Never inspects other claim shapes.
+    """
+    if not claims:
+        return None
+    sub = claims.get('sub')
+    if not sub:
+        return None
+    preview = safe_preview(str(sub), _PRINCIPAL_PREVIEW_MAX_CHARS)
+    return preview or None
+
+
+def tenant_from_claims(claims: Mapping[str, Any] | None) -> str | None:
+    """Derive a safe tenant identifier from verified claims, if present."""
+    if not claims:
+        return None
+    tenant = claims.get('tenant') or claims.get('tenant_id')
+    if not tenant:
+        return None
+    preview = safe_preview(str(tenant), _PRINCIPAL_PREVIEW_MAX_CHARS)
+    return preview or None

--- a/services/api-gateway/src/runtime/registry.py
+++ b/services/api-gateway/src/runtime/registry.py
@@ -114,6 +114,7 @@ from importlib.metadata import entry_points
 from typing import Any
 
 __all__ = [
+    'AuditWriteError',
     'AuthorizationError',
     'RbacDenied',
     'SideEffect',
@@ -126,6 +127,20 @@ __all__ = [
 ]
 
 
+from runtime.audit import (
+    AuditDecision,
+    AuditEvent,
+    AuditWriteError,
+    AuditWriter,
+    ClockFn,
+    EventIdFn,
+    InMemoryAuditWriter,
+    build_args_preview,
+    default_clock,
+    default_event_id,
+    principal_from_claims,
+    tenant_from_claims,
+)
 from runtime.authz import (
     APPROVAL_FIELDS,
     AuthorizationError,
@@ -134,6 +149,7 @@ from runtime.authz import (
     approval_from_mapping,
     authorize_tool,
     coerce_side_effect,
+    normalize_roles,
     roles_from_claims,
     validate_tool_metadata,
 )
@@ -230,10 +246,32 @@ class ToolInfo:
 class ToolRegistry:
     """Prosty, bezpieczny wątkowo rejestr narzędzi dla runtime."""
 
-    def __init__(self) -> None:
-        """Inicjalizacja klasa."""
+    def __init__(
+        self,
+        *,
+        audit_writer: AuditWriter | None = None,
+        audit_event_id: EventIdFn = default_event_id,
+        audit_clock: ClockFn = default_clock,
+    ) -> None:
+        """Inicjalizacja klasa.
+
+        Args:
+            audit_writer: Durable(-compatible) sink for side-effect audit
+                events (ISSUE 019). Defaults to :class:`InMemoryAuditWriter`,
+                which never raises, so existing callers/tests that do not
+                configure a sink keep working unchanged. Production wiring
+                should inject a durable writer (e.g. ``FileAuditWriter``).
+            audit_event_id: Injectable event-id generator (``INV-AUDIT-7``);
+                override in tests for deterministic ids.
+            audit_clock: Injectable UTC clock (``INV-AUDIT-7``); override in
+                tests for deterministic timestamps.
+
+        """
         self._tools: dict[str, ToolInfo] = {}
         self._lock = asyncio.Lock()
+        self._audit_writer: AuditWriter = audit_writer or InMemoryAuditWriter()
+        self._audit_event_id = audit_event_id
+        self._audit_clock = audit_clock
 
     # Mutacje
     async def register(
@@ -355,6 +393,99 @@ class ToolRegistry:
         """Czy narzędzie jest zarejestrowane?"""
         return name in self._tools
 
+    async def _emit_audit(
+        self,
+        *,
+        tool: str,
+        side_effect: SideEffect,
+        decision: AuditDecision,
+        roles: tuple[str, ...],
+        trace_id: str | None,
+        request_id: str | None,
+        tenant_id: str | None,
+        principal_id: str | None,
+        approval_id: str | None,
+        args_preview: dict[str, Any],
+        reason: str | None = None,
+        error_type: str | None = None,
+        fail_closed: bool,
+    ) -> None:
+        """Durably record one audit event (ISSUE 019); fail-closed when asked.
+
+        ``fail_closed`` gates whether a writer failure is escalated into
+        :class:`AuditWriteError` (``INV-AUDIT-5``, ``write``/``execute`` only)
+        or merely logged and swallowed (best-effort, used for the post-execution
+        error record so a tool's real exception is never masked by an audit
+        write problem).
+        """
+        event = AuditEvent(
+            event_id=self._audit_event_id(),
+            timestamp=self._audit_clock(),
+            tool=tool,
+            side_effect=side_effect,
+            decision=decision,
+            roles=roles,
+            trace_id=trace_id,
+            request_id=request_id,
+            tenant_id=tenant_id,
+            principal_id=principal_id,
+            reason=reason,
+            approval_id=approval_id,
+            args_preview=args_preview,
+            error_type=error_type,
+        )
+        try:
+            await self._audit_writer.write(event)
+        except Exception as exc:
+            _logger.critical(
+                "Audit write failed: tool='%s' decision=%s writer=%s: %s",
+                tool,
+                decision.value,
+                type(self._audit_writer).__name__,
+                type(exc).__name__,
+            )
+            if fail_closed:
+                raise AuditWriteError(tool) from exc
+
+    @staticmethod
+    def _strip_meta_kwargs(kwargs: dict[str, Any], sig: inspect.Signature | None) -> dict[str, Any]:
+        """Strip ``claims``/approval meta keys the callable does not declare."""
+        if sig is None:
+            return kwargs
+        meta_keys = [k for k in ('claims', *APPROVAL_FIELDS) if k in kwargs]
+        to_strip = [k for k in meta_keys if k not in sig.parameters]
+        if not to_strip:
+            return kwargs
+        kwargs = dict(kwargs)  # płytka kopia
+        for key in to_strip:
+            kwargs.pop(key, None)
+        return kwargs
+
+    async def _invoke_tool(
+        self,
+        name: str,
+        info: ToolInfo,
+        kwargs: dict[str, Any],
+        *,
+        is_side_effecting: bool,
+        emit: Callable[..., Any],
+    ) -> Any:
+        """Run the tool's callable (sync/async) and audit an ``ERROR`` outcome.
+
+        A writer failure here is best-effort (``fail_closed=False``): the
+        tool's own exception is what the caller needs to see, so an audit
+        write problem is logged but never masks it.
+        """
+        try:
+            if info.is_coroutine:
+                return await info.fn(**kwargs)
+            return await asyncio.to_thread(info.fn, **kwargs)
+        except Exception as exc:  # logujemy, nie maskujemy
+            _logger.exception("Tool '%s' failed: %s", name, exc)
+            if is_side_effecting:
+                await emit(AuditDecision.ERROR, error_type=type(exc).__name__, fail_closed=False)
+            raise
+
     # Wykonanie
     async def execute(
         self,
@@ -362,14 +493,24 @@ class ToolRegistry:
         *,
         roles: Iterable[str] | None = None,
         approval_id: str | None = None,
+        trace_id: str | None = None,
+        request_id: str | None = None,
+        tenant_id: str | None = None,
+        principal_id: str | None = None,
         **kwargs: Any,
     ) -> Any:
-        """Uruchamia narzędzie — jedyny punkt egzekwowania RBAC (ISSUE 016).
+        """Uruchamia narzędzie — jedyny punkt egzekwowania RBAC (ISSUE 016)
+        i durable audytu dla narzędzi side-effecting (ISSUE 019).
 
         This is the single authorization choke point that both the LLM-planned
         and keyword-fallback paths traverse (``INV-DUAL-PATH``). The decision is
         delegated to :func:`runtime.authz.authorize_tool` and made from
-        *normalized roles only*.
+        *normalized roles only*. For ``write``/``execute`` tools, every attempt
+        — denied, allowed, or erroring — is durably recorded through the
+        configured :class:`~runtime.audit.AuditWriter` before the caller
+        observes the outcome (``INV-AUDIT-1``/``INV-AUDIT-2``). ``read`` tools
+        never touch the audit writer, so a broken sink can never block a read
+        (``INV-AUDIT-6``).
 
         Args:
             roles: The principal's normalized roles. When ``None`` (legacy
@@ -381,6 +522,14 @@ class ToolRegistry:
                 ``change_record_id``). ``write``/``execute`` tools are denied
                 (``APPROVAL_REQUIRED``) before execution if none is present
                 (``INV-RBAC-4``).
+            trace_id: Optional OTel/request trace id, recorded on the audit
+                event for incident correlation when supplied (``INV-AUDIT-4``).
+            request_id: Optional request correlation id, recorded on the audit
+                event when supplied.
+            tenant_id: Optional explicit tenant id. When not given, derived
+                from ``claims`` (``tenant``/``tenant_id``) if present.
+            principal_id: Optional explicit safe subject id. When not given,
+                derived from ``claims['sub']`` if present.
 
         Sync/Async:
             - Funkcje asynchroniczne awaitujemy bezpośrednio.
@@ -389,16 +538,49 @@ class ToolRegistry:
         Raises:
             RbacDenied: gdy wywołanie nie jest autoryzowane (przed wykonaniem fn).
             ToolNotFoundError: gdy narzędzie nie istnieje.
+            AuditWriteError: gdy audyt narzędzia side-effecting nie mógł zostać
+                trwale zapisany (``write``/``execute`` fail-closed, ISSUE 019).
             Dowolny wyjątek biznesowy narzędzia (przepuszczamy, ale logujemy).
 
         """
         info = self.get_info(name)
+        is_side_effecting = info.side_effect in _SIDE_EFFECTING
 
         # 1 RBAC choke point (shared by every execution path; fail-closed).
         effective_roles = roles_from_claims(kwargs.get('claims')) if roles is None else roles
         # Approval/change-record id may arrive explicitly or in the invocation
         # arguments/context; the explicit value takes precedence.
         effective_approval_id = approval_id or approval_from_mapping(kwargs)
+
+        # Audit correlation data (ISSUE 019) is captured once, from the
+        # original invocation kwargs, *before* any RBAC decision or meta-kwarg
+        # stripping — so DENIED/ALLOWED/ERROR events for the same call always
+        # report identical roles/principal/tenant/args_preview regardless of
+        # what the tool's own signature does with ``claims``. Only computed
+        # for side-effecting tools; the read-tool path never touches this.
+        audit_fields: dict[str, Any] = {}
+        if is_side_effecting:
+            claims = kwargs.get('claims')
+            audit_fields = {
+                'roles': tuple(sorted(normalize_roles(effective_roles))),
+                'tenant_id': tenant_id or tenant_from_claims(claims),
+                'principal_id': principal_id or principal_from_claims(claims),
+                'args_preview': build_args_preview(kwargs),
+            }
+
+        async def _emit(decision: AuditDecision, *, fail_closed: bool, **overrides: Any) -> None:
+            await self._emit_audit(
+                tool=name,
+                side_effect=info.side_effect,
+                decision=decision,
+                trace_id=trace_id,
+                request_id=request_id,
+                approval_id=effective_approval_id,
+                fail_closed=fail_closed,
+                **audit_fields,
+                **overrides,
+            )
+
         try:
             authorize_tool(
                 tool=name,
@@ -415,30 +597,23 @@ class ToolRegistry:
                 exc.reason.value,
                 list(exc.needed_roles),
             )
+            if is_side_effecting:
+                await _emit(AuditDecision.DENIED, reason=exc.reason.value, fail_closed=True)
             raise
 
         # 2 Czyszczenie kwargs: meta keys ('claims' and the approval fields) are
         #    stripped when the callable does not declare them, so they never leak
         #    into business tool signatures.
-        sig = info.signature
-        if sig is not None:
-            meta_keys = [k for k in ('claims', *APPROVAL_FIELDS) if k in kwargs]
-            to_strip = [k for k in meta_keys if k not in sig.parameters]
-            if to_strip:
-                kwargs = dict(kwargs)  # płytka kopia
-                for key in to_strip:
-                    kwargs.pop(key, None)
+        kwargs = self._strip_meta_kwargs(kwargs, info.signature)
+
+        # 2b Fail-closed pre-execution audit for authorized side-effecting
+        #    attempts (INV-AUDIT-5): the durable ALLOWED record is written
+        #    *before* the tool runs. If the writer fails, the tool function is
+        #    never invoked and AuditWriteError propagates instead.
+        if is_side_effecting:
+            await _emit(AuditDecision.ALLOWED, fail_closed=True)
 
         # 3 Uruchomienie narzędzia obsługa sync/async
-        if info.is_coroutine:
-            try:
-                return await info.fn(**kwargs)
-            except Exception as exc:  # logujemy, nie maskujemy
-                _logger.exception("Async tool '%s' failed: %s", name, exc)
-                raise
-        else:
-            try:
-                return await asyncio.to_thread(info.fn, **kwargs)
-            except Exception as exc:
-                _logger.exception("Sync tool '%s' failed: %s", name, exc)
-                raise
+        return await self._invoke_tool(
+            name, info, kwargs, is_side_effecting=is_side_effecting, emit=_emit
+        )

--- a/services/api-gateway/tests/runtime/test_audit.py
+++ b/services/api-gateway/tests/runtime/test_audit.py
@@ -1,0 +1,590 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/tests/runtime/test_audit.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Verifies AstraDesk behavior for the associated component.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Durable audit trail tests for side-effecting tool execution (ISSUE 019).
+
+Exercises the audit choke point wired into ``ToolRegistry.execute`` (ISSUE
+016's shared RBAC choke point). Both the LLM-planned and keyword-fallback
+paths call this exact method (see ``test_rbac_invariant.py``), so auditing it
+here makes every side-effect attempt auditable regardless of caller
+(``INV-DUAL-PATH``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from astradesk_core.redaction import (
+    PLACEHOLDER_EMAIL,
+    PLACEHOLDER_PRIVATE_KEY,
+    PLACEHOLDER_SECRET,
+    PLACEHOLDER_TOKEN,
+)
+from runtime.audit import (
+    AuditDecision,
+    AuditEvent,
+    AuditWriteError,
+    FileAuditWriter,
+    InMemoryAuditWriter,
+    build_args_preview,
+    principal_from_claims,
+    tenant_from_claims,
+)
+from runtime.authz import RbacDenied, RbacReason, SideEffect
+from runtime.planner import KeywordPlanner
+from runtime.registry import ToolRegistry
+
+# A representative leak corpus: (secret_fragment, raw_value, expected_placeholder).
+_LEAK_CORPUS = [
+    ('victim@example.com', 'contact victim@example.com about this', PLACEHOLDER_EMAIL),
+    (
+        'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345',
+        'token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345',
+        PLACEHOLDER_TOKEN,
+    ),
+    ('hunter2secret', 'password=hunter2secret', PLACEHOLDER_SECRET),
+    (
+        'MIIEowIBAAKCAQEA1234567890abcdef',
+        '-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA1234567890abcdef\n-----END RSA PRIVATE KEY-----',
+        PLACEHOLDER_PRIVATE_KEY,
+    ),
+]
+
+
+class _BrokenWriter:
+    """An ``AuditWriter`` that always fails; used for fail-closed tests."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def write(self, event: AuditEvent) -> None:
+        self.calls += 1
+        raise OSError('simulated audit sink outage')
+
+
+class _Spy:
+    """Records whether the underlying tool function ran, mirroring the
+    dual-path helper in ``test_rbac_invariant.py``."""
+
+    def __init__(self, *, raises: Exception | None = None) -> None:
+        self.called = False
+        self._raises = raises
+
+    def as_tool(self):
+        async def fn(*, service: str = '', **_: object) -> str:
+            self.called = True
+            if self._raises is not None:
+                raise self._raises
+            return f'executed:{service}'
+
+        return fn
+
+
+async def _register(
+    registry: ToolRegistry,
+    spy: _Spy,
+    *,
+    name: str = 'restart_service',
+    side_effect: SideEffect = SideEffect.EXECUTE,
+    allowed_roles: set[str] | None = None,
+) -> None:
+    await registry.register(
+        name,
+        spy.as_tool(),
+        side_effect=side_effect,
+        allowed_roles=allowed_roles if allowed_roles is not None else {'sre'},
+    )
+
+
+# === 1 & 2. Successful write/execute tool emits exactly one audit event ==== #
+
+
+@pytest.mark.parametrize('side_effect', [SideEffect.WRITE, SideEffect.EXECUTE])
+@pytest.mark.asyncio
+async def test_successful_side_effect_tool_emits_one_audit_event(side_effect: SideEffect) -> None:
+    writer = InMemoryAuditWriter()
+    registry = ToolRegistry(audit_writer=writer)
+    spy = _Spy()
+    await _register(registry, spy, side_effect=side_effect)
+
+    result = await registry.execute(
+        'restart_service', roles=('sre',), approval_id='CHG-1001', service='webapp'
+    )
+
+    assert result == 'executed:webapp'
+    assert spy.called is True
+    assert len(writer.events) == 1
+    event = writer.events[0]
+    assert event.decision is AuditDecision.ALLOWED
+    assert event.tool == 'restart_service'
+    assert event.side_effect is side_effect
+    assert event.approval_id == 'CHG-1001'
+
+
+# === 3 & 4. RBAC-denied / missing-approval side-effect attempts audited ==== #
+
+
+@pytest.mark.asyncio
+async def test_rbac_denied_side_effect_emits_denied_audit_event() -> None:
+    writer = InMemoryAuditWriter()
+    registry = ToolRegistry(audit_writer=writer)
+    spy = _Spy()
+    await _register(registry, spy)
+
+    with pytest.raises(RbacDenied) as excinfo:
+        await registry.execute('restart_service', roles=('viewer',), service='webapp')
+
+    assert spy.called is False
+    assert len(writer.events) == 1
+    event = writer.events[0]
+    assert event.decision is AuditDecision.DENIED
+    assert event.reason == excinfo.value.reason.value == RbacReason.ROLE_DENIED.value
+
+
+@pytest.mark.asyncio
+async def test_missing_approval_emits_denied_audit_event() -> None:
+    writer = InMemoryAuditWriter()
+    registry = ToolRegistry(audit_writer=writer)
+    spy = _Spy()
+    await _register(registry, spy)
+
+    with pytest.raises(RbacDenied):
+        # Matching role, but no approval/change record (INV-RBAC-4).
+        await registry.execute('restart_service', roles=('sre',), service='webapp')
+
+    assert spy.called is False
+    assert len(writer.events) == 1
+    assert writer.events[0].decision is AuditDecision.DENIED
+    assert writer.events[0].reason == RbacReason.APPROVAL_REQUIRED.value
+
+
+# === 5. Tool execution exception emits an error audit event =============== #
+
+
+@pytest.mark.asyncio
+async def test_tool_exception_emits_error_audit_event() -> None:
+    writer = InMemoryAuditWriter()
+    registry = ToolRegistry(audit_writer=writer)
+    spy = _Spy(raises=RuntimeError('boom'))
+    await _register(registry, spy)
+
+    with pytest.raises(RuntimeError, match='boom'):
+        await registry.execute(
+            'restart_service', roles=('sre',), approval_id='CHG-1002', service='webapp'
+        )
+
+    assert spy.called is True
+    error_events = [e for e in writer.events if e.decision is AuditDecision.ERROR]
+    assert len(error_events) == 1
+    assert error_events[0].error_type == 'RuntimeError'
+    # The exception message ('boom') must never appear in the audit record.
+    assert 'boom' not in str(error_events[0].args_preview)
+
+
+# === 6. Audit writer failure blocks write/execute tools (fail-closed) ====== #
+
+
+@pytest.mark.parametrize('side_effect', [SideEffect.WRITE, SideEffect.EXECUTE])
+@pytest.mark.asyncio
+async def test_audit_writer_failure_blocks_side_effect_tool(side_effect: SideEffect) -> None:
+    writer = _BrokenWriter()
+    registry = ToolRegistry(audit_writer=writer)
+    spy = _Spy()
+    await _register(registry, spy, side_effect=side_effect)
+
+    with pytest.raises(AuditWriteError):
+        await registry.execute(
+            'restart_service', roles=('sre',), approval_id='CHG-1003', service='webapp'
+        )
+
+    assert spy.called is False  # tool must never run without durable evidence
+    assert writer.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_audit_writer_failure_error_does_not_leak_writer_exception_text() -> None:
+    writer = _BrokenWriter()
+    registry = ToolRegistry(audit_writer=writer)
+    spy = _Spy()
+    await _register(registry, spy)
+
+    with pytest.raises(AuditWriteError) as excinfo:
+        await registry.execute(
+            'restart_service', roles=('sre',), approval_id='CHG-1004', service='webapp'
+        )
+
+    assert 'simulated audit sink outage' not in str(excinfo.value)
+    assert excinfo.value.code == 'AUDIT_SINK_UNAVAILABLE'
+
+
+# === 7. Audit writer failure never blocks a read tool ====================== #
+
+
+@pytest.mark.asyncio
+async def test_audit_writer_failure_does_not_block_read_tool() -> None:
+    writer = _BrokenWriter()
+    registry = ToolRegistry(audit_writer=writer)
+    spy = _Spy()
+    await registry.register('get_metrics', spy.as_tool(), side_effect=SideEffect.READ)
+
+    result = await registry.execute('get_metrics', roles=(), service='webapp')
+
+    assert result == 'executed:webapp'
+    assert spy.called is True
+    assert writer.calls == 0  # read tools never touch the audit writer
+
+
+# === 8 & 11. Argument preview / audit payload redaction ==================== #
+
+
+@pytest.mark.parametrize('fragment,raw,placeholder', _LEAK_CORPUS)
+@pytest.mark.asyncio
+async def test_args_preview_redacts_leak_corpus(fragment: str, raw: str, placeholder: str) -> None:
+    writer = InMemoryAuditWriter()
+    registry = ToolRegistry(audit_writer=writer)
+    spy = _Spy()
+    await _register(registry, spy, name='create_ticket', side_effect=SideEffect.WRITE)
+
+    await registry.execute(
+        'create_ticket',
+        roles=('sre',),
+        approval_id='CHG-2001',
+        claims={'sub': 'user-1', 'access_token': 'super-secret-token-value'},
+        service=raw,
+    )
+
+    event = writer.events[0]
+    rendered = str(event.args_preview)
+    assert fragment not in rendered, 'raw leak-corpus fragment survived into the audit preview'
+    assert placeholder in rendered
+    # The raw claims container itself must never be echoed into the preview.
+    assert 'super-secret-token-value' not in rendered
+    assert 'access_token' not in event.args_preview
+
+
+@pytest.mark.asyncio
+async def test_no_audit_event_contains_raw_leak_corpus_values() -> None:
+    """Regression: across every emitted event (denied/allowed/error), no raw
+    leak-corpus fragment survives, whatever the outcome (INV-AUDIT-3)."""
+    writer = InMemoryAuditWriter()
+    registry = ToolRegistry(audit_writer=writer)
+
+    secret_claims = {
+        'sub': 'user-1',
+        'password': 'hunter2secret',
+        'access_token': 'eyJhbGci.abc.def',
+    }
+
+    denied_spy = _Spy()
+    await _register(registry, denied_spy, name='denied_tool')
+    with pytest.raises(RbacDenied):
+        await registry.execute(
+            'denied_tool', roles=('viewer',), claims=secret_claims, service='alice@example.com'
+        )
+
+    allowed_spy = _Spy()
+    await _register(registry, allowed_spy, name='allowed_tool')
+    await registry.execute(
+        'allowed_tool',
+        roles=('sre',),
+        approval_id='CHG-3001',
+        claims=secret_claims,
+        service='alice@example.com',
+    )
+
+    error_spy = _Spy(raises=ValueError('leak alice@example.com in error'))
+    await _register(registry, error_spy, name='error_tool')
+    with pytest.raises(ValueError, match='leak'):
+        await registry.execute(
+            'error_tool',
+            roles=('sre',),
+            approval_id='CHG-3002',
+            claims=secret_claims,
+            service='alice@example.com',
+        )
+
+    # denied_tool -> 1 DENIED event. allowed_tool (succeeds) -> 1 pre-execution
+    # ALLOWED event. error_tool (RBAC allows, then raises) -> the pre-execution
+    # ALLOWED event plus a post-execution ERROR event. 4 events total.
+    assert len(writer.events) == 4
+    blob = '\n'.join(str(e.to_dict()) for e in writer.events)
+    assert 'hunter2secret' not in blob
+    assert 'eyJhbGci.abc.def' not in blob
+    assert 'alice@example.com' not in blob
+
+
+def test_build_args_preview_excludes_meta_keys() -> None:
+    preview = build_args_preview(
+        {
+            'claims': {'sub': 'user-1', 'password': 'hunter2'},
+            'approval_id': 'CHG-9001',
+            'change_record': 'CHG-9002',
+            'service': 'webapp',
+        }
+    )
+    assert 'claims' not in preview
+    assert 'approval_id' not in preview
+    assert 'change_record' not in preview
+    assert preview['service'] == 'webapp'
+
+
+def test_build_args_preview_is_bounded() -> None:
+    huge = {f'k{i}': 'x' * 5000 for i in range(50)}
+    preview = build_args_preview(huge)
+    assert preview.get('_truncated') is True
+    assert len(preview) <= 21  # 20 keys + the truncation marker
+    for value in preview.values():
+        if isinstance(value, str):
+            assert len(value) <= 201  # bounded chars + ellipsis
+
+
+# === 9. Correlation fields present when provided (or safely derived) ======= #
+
+
+@pytest.mark.asyncio
+async def test_audit_event_includes_correlation_fields_when_provided() -> None:
+    writer = InMemoryAuditWriter()
+    registry = ToolRegistry(audit_writer=writer)
+    spy = _Spy()
+    await _register(registry, spy)
+
+    await registry.execute(
+        'restart_service',
+        roles=('sre',),
+        approval_id='CHG-4001',
+        trace_id='trace-abc',
+        request_id='req-xyz',
+        tenant_id='acme',
+        principal_id='user-explicit',
+        service='webapp',
+    )
+
+    event = writer.events[0]
+    assert event.trace_id == 'trace-abc'
+    assert event.request_id == 'req-xyz'
+    assert event.tenant_id == 'acme'
+    assert event.principal_id == 'user-explicit'
+    assert event.roles == ('sre',)
+    assert event.tool == 'restart_service'
+    assert event.side_effect is SideEffect.EXECUTE
+    assert event.decision is AuditDecision.ALLOWED
+    assert event.event_id
+    assert isinstance(event.timestamp, datetime)
+    assert event.timestamp.tzinfo is not None  # timezone-aware UTC (INV-AUDIT-7)
+
+
+@pytest.mark.asyncio
+async def test_audit_event_derives_principal_and_tenant_from_claims_when_not_explicit() -> None:
+    writer = InMemoryAuditWriter()
+    registry = ToolRegistry(audit_writer=writer)
+    spy = _Spy()
+    await _register(registry, spy)
+
+    await registry.execute(
+        'restart_service',
+        roles=('sre',),
+        approval_id='CHG-4002',
+        claims={'sub': 'user-42', 'tenant': 'acme-corp'},
+        service='webapp',
+    )
+
+    event = writer.events[0]
+    assert event.principal_id == 'user-42'
+    assert event.tenant_id == 'acme-corp'
+
+
+@pytest.mark.asyncio
+async def test_denied_and_allowed_events_report_identical_correlation_fields() -> None:
+    """Regression: correlation fields must not depend on whether the tool's
+    signature happens to declare ``claims`` (kwargs stripping must not change
+    what the audit layer observes)."""
+    writer = InMemoryAuditWriter()
+    registry = ToolRegistry(audit_writer=writer)
+
+    denied_spy = _Spy()
+    await _register(registry, denied_spy, name='deny_me')
+    with pytest.raises(RbacDenied):
+        await registry.execute(
+            'deny_me', roles=('viewer',), claims={'sub': 'user-7', 'tenant': 'acme'}, service='x'
+        )
+
+    allowed_spy = _Spy()
+    await _register(registry, allowed_spy, name='allow_me')
+    await registry.execute(
+        'allow_me',
+        roles=('sre',),
+        approval_id='CHG-5001',
+        claims={'sub': 'user-7', 'tenant': 'acme'},
+        service='x',
+    )
+
+    denied_event, allowed_event = writer.events
+    assert denied_event.principal_id == allowed_event.principal_id == 'user-7'
+    assert denied_event.tenant_id == allowed_event.tenant_id == 'acme'
+
+
+def test_principal_and_tenant_from_claims_helpers() -> None:
+    assert principal_from_claims(None) is None
+    assert principal_from_claims({}) is None
+    assert principal_from_claims({'sub': 'user-1'}) == 'user-1'
+    assert tenant_from_claims({'tenant': 'acme'}) == 'acme'
+    assert tenant_from_claims({'tenant_id': 'acme-2'}) == 'acme-2'
+    assert tenant_from_claims({}) is None
+
+
+# === 10. Both LLM-planned and keyword-fallback paths are auditable ========= #
+
+
+async def _invoke_as_agent_path(
+    registry: ToolRegistry,
+    name: str,
+    roles: tuple[str, ...],
+    *,
+    approval_id: str | None = None,
+    **args: object,
+) -> object:
+    """Mirror the exact call both runtime paths make to the choke point (see
+    ``test_rbac_invariant.py::_invoke_as_agent_path``)."""
+    return await registry.execute(name, roles=roles, approval_id=approval_id, claims={}, **args)
+
+
+@pytest.mark.parametrize('path', ['llm_planned', 'keyword_fallback'])
+@pytest.mark.asyncio
+async def test_dual_path_authorized_side_effect_is_audited(path: str) -> None:
+    writer = InMemoryAuditWriter()
+    registry = ToolRegistry(audit_writer=writer)
+    spy = _Spy()
+    await _register(registry, spy)
+
+    if path == 'keyword_fallback':
+        steps = KeywordPlanner().make_plan('please restart webapp now')
+        name, args = steps[0].name, steps[0].arguments
+    else:
+        name, args = 'restart_service', {'service': 'webapp'}
+
+    result = await _invoke_as_agent_path(registry, name, ('sre',), approval_id='CHG-6001', **args)
+
+    assert result == 'executed:webapp'
+    assert len(writer.events) == 1
+    assert writer.events[0].decision is AuditDecision.ALLOWED
+
+
+@pytest.mark.parametrize('path', ['llm_planned', 'keyword_fallback'])
+@pytest.mark.asyncio
+async def test_dual_path_unauthorized_side_effect_is_audited(path: str) -> None:
+    writer = InMemoryAuditWriter()
+    registry = ToolRegistry(audit_writer=writer)
+    spy = _Spy()
+    await _register(registry, spy)
+
+    if path == 'keyword_fallback':
+        steps = KeywordPlanner().make_plan('please restart webapp now')
+        name, args = steps[0].name, steps[0].arguments
+    else:
+        name, args = 'restart_service', {'service': 'webapp'}
+
+    with pytest.raises(RbacDenied):
+        await _invoke_as_agent_path(registry, name, ('viewer',), **args)
+
+    assert spy.called is False
+    assert len(writer.events) == 1
+    assert writer.events[0].decision is AuditDecision.DENIED
+
+
+# === FileAuditWriter: real append-only local durability ==================== #
+
+
+@pytest.mark.asyncio
+async def test_file_audit_writer_appends_json_lines(tmp_path: Any) -> None:
+    path = tmp_path / 'audit' / 'events.jsonl'
+    writer = FileAuditWriter(path)
+    event = AuditEvent(
+        event_id='audit-1',
+        timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        tool='restart_service',
+        side_effect=SideEffect.EXECUTE,
+        decision=AuditDecision.ALLOWED,
+        roles=('sre',),
+        approval_id='CHG-1',
+    )
+
+    await writer.write(event)
+    await writer.write(event)
+
+    lines = path.read_text(encoding='utf-8').strip().splitlines()
+    assert len(lines) == 2
+    assert '"tool":"restart_service"' in lines[0]
+    assert '"decision":"allowed"' in lines[0]
+
+
+@pytest.mark.asyncio
+async def test_file_audit_writer_survives_reinstantiation(tmp_path: Any) -> None:
+    """A fresh writer instance appends rather than truncating (durability
+    across process restarts on the same host)."""
+    path = tmp_path / 'events.jsonl'
+    event = AuditEvent(
+        event_id='audit-1',
+        timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        tool='t',
+        side_effect=SideEffect.WRITE,
+        decision=AuditDecision.ALLOWED,
+    )
+
+    await FileAuditWriter(path).write(event)
+    await FileAuditWriter(path).write(event)
+
+    lines = path.read_text(encoding='utf-8').strip().splitlines()
+    assert len(lines) == 2
+
+
+# === Default writer wiring: existing/legacy callers keep working =========== #
+
+
+@pytest.mark.asyncio
+async def test_default_registry_uses_in_memory_audit_writer_and_never_blocks() -> None:
+    registry = ToolRegistry()  # no audit_writer supplied — legacy construction
+    spy = _Spy()
+    await _register(registry, spy)
+
+    result = await registry.execute(
+        'restart_service', roles=('sre',), approval_id='CHG-7001', service='webapp'
+    )
+
+    assert result == 'executed:webapp'
+    assert isinstance(registry._audit_writer, InMemoryAuditWriter)  # type: ignore[attr-defined]
+    assert len(registry._audit_writer.events) == 1  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_injected_clock_and_event_id_are_deterministic() -> None:
+    writer = InMemoryAuditWriter()
+    fixed_time = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    registry = ToolRegistry(
+        audit_writer=writer,
+        audit_event_id=lambda: 'audit-fixed-id',
+        audit_clock=lambda: fixed_time,
+    )
+    spy = _Spy()
+    await _register(registry, spy)
+
+    await registry.execute(
+        'restart_service', roles=('sre',), approval_id='CHG-8001', service='webapp'
+    )
+
+    event = writer.events[0]
+    assert event.event_id == 'audit-fixed-id'
+    assert event.timestamp == fixed_time

--- a/services/api-gateway/tests/runtime/test_audit.py
+++ b/services/api-gateway/tests/runtime/test_audit.py
@@ -455,7 +455,7 @@ async def _invoke_as_agent_path(
     roles: tuple[str, ...],
     *,
     approval_id: str | None = None,
-    **args: object,
+    **args: Any,
 ) -> object:
     """Mirror the exact call both runtime paths make to the choke point (see
     ``test_rbac_invariant.py::_invoke_as_agent_path``)."""

--- a/services/api-gateway/tests/runtime/test_audit_startup.py
+++ b/services/api-gateway/tests/runtime/test_audit_startup.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/tests/runtime/test_audit_startup.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Verifies AstraDesk behavior for the associated component.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Startup-time audit sink selection tests (ISSUE 019).
+
+Verifies that ``gateway.main._resolve_audit_writer`` — called from
+``lifespan`` before any external resource (DB/Redis) is touched — fails
+closed on a deployed tier without a durable sink, mirrors the OIDC
+fail-closed default (``ENVIRONMENT`` unset => ``'production'``), and still
+allows the non-durable in-process writer for local/dev/test tiers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from gateway import main as gateway_main
+from runtime.audit import FileAuditWriter, InMemoryAuditWriter
+
+# === Config-selection unit tests (no ASGI lifespan involved) =============== #
+
+
+def test_resolve_audit_writer_uses_file_writer_when_path_set(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv('AUDIT_LOG_PATH', str(tmp_path / 'audit.jsonl'))
+    monkeypatch.setenv('ENVIRONMENT', 'production')
+
+    writer = gateway_main._resolve_audit_writer()
+
+    assert isinstance(writer, FileAuditWriter)
+
+
+@pytest.mark.parametrize('tier', ['production', 'prod', 'staging', 'stage', 'PRODUCTION'])
+def test_resolve_audit_writer_fails_closed_on_deployed_tier_without_path(
+    tier: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv('AUDIT_LOG_PATH', raising=False)
+    monkeypatch.setenv('ENVIRONMENT', tier)
+
+    with pytest.raises(gateway_main.AuditConfigError) as excinfo:
+        gateway_main._resolve_audit_writer()
+
+    # The error must name the tier/missing variable, never a secret or payload.
+    assert 'AUDIT_LOG_PATH' in str(excinfo.value)
+
+
+def test_resolve_audit_writer_defaults_to_production_when_environment_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No AUDIT_LOG_PATH, no ENVIRONMENT at all: must fail closed, matching the
+    # same fail-closed default as astradesk_core.utils.oidc.build_verifier_from_env.
+    monkeypatch.delenv('AUDIT_LOG_PATH', raising=False)
+    monkeypatch.delenv('ENVIRONMENT', raising=False)
+
+    with pytest.raises(gateway_main.AuditConfigError):
+        gateway_main._resolve_audit_writer()
+
+
+@pytest.mark.parametrize('tier', ['dev', 'test', 'local', 'ci'])
+def test_resolve_audit_writer_allows_in_memory_writer_outside_deployed_tier(
+    tier: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv('AUDIT_LOG_PATH', raising=False)
+    monkeypatch.setenv('ENVIRONMENT', tier)
+
+    writer = gateway_main._resolve_audit_writer()
+
+    assert isinstance(writer, InMemoryAuditWriter)
+
+
+def test_resolve_audit_writer_warns_when_falling_back_to_in_memory(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.delenv('AUDIT_LOG_PATH', raising=False)
+    monkeypatch.setenv('ENVIRONMENT', 'dev')
+
+    with caplog.at_level('WARNING', logger=gateway_main.logger.name):
+        gateway_main._resolve_audit_writer()
+
+    assert any('AUDIT_LOG_PATH not set' in rec.message for rec in caplog.records)
+
+
+# === Full lifespan: fail-closed before DB/Redis are touched ================ #
+
+
+@pytest.mark.asyncio
+async def test_lifespan_fails_closed_before_database_when_audit_unconfigured_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv('AUDIT_LOG_PATH', raising=False)
+    monkeypatch.setenv('ENVIRONMENT', 'production')
+    monkeypatch.setattr(gateway_main, 'install_verifier', lambda app: None)
+
+    async def unexpected_pool_creation(*args: object, **kwargs: object) -> None:
+        pytest.fail('database initialization ran before the audit sink check')
+
+    monkeypatch.setattr(gateway_main.asyncpg, 'create_pool', unexpected_pool_creation)
+
+    with pytest.raises(gateway_main.AuditConfigError):
+        async with gateway_main.lifespan(gateway_main.app):
+            pytest.fail('lifespan yielded despite missing durable audit sink')
+
+
+# A full-lifespan "dev tier does not fail closed" sanity check is already
+# covered end-to-end by ``tests/test_api.py::test_healthz_ok``, which runs the
+# real ``lifespan`` with ``ENVIRONMENT=dev`` and no ``AUDIT_LOG_PATH`` and
+# succeeds; duplicating that here would mean re-mocking the entire startup
+# chain (DB pool, Redis, RAG, domain-pack loading) for no additional signal.

--- a/services/api-gateway/tests/runtime/test_rbac_invariant.py
+++ b/services/api-gateway/tests/runtime/test_rbac_invariant.py
@@ -24,6 +24,8 @@ that an unauthorized side-effect call is denied identically in every cell.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from runtime.authz import (
     AuthorizationError,
@@ -178,7 +180,7 @@ async def _invoke_as_agent_path(
     roles: tuple[str, ...],
     *,
     approval_id: str | None = None,
-    **args: object,
+    **args: Any,
 ) -> object:
     """Mirror the exact call both runtime paths make to the choke point.
 


### PR DESCRIPTION
Summary

Implements ISSUE #019: durable audit trail for side-effect tool execution at the ToolRegistry.execute choke point.

What changed

- Added typed audit event schema and writer abstraction.
- Added FileAuditWriter for append-only JSONL durable audit.
- Added InMemoryAuditWriter for dev/test/local/ci only.
- Added production/staging fail-closed audit configuration:
  - AUDIT_LOG_PATH set -> FileAuditWriter.
  - production/staging without AUDIT_LOG_PATH -> startup aborts with AuditConfigError.
  - dev/test/local/ci without AUDIT_LOG_PATH -> InMemoryAuditWriter with warning.
- Wired audit emission into ToolRegistry.execute.
- Added audit events for allowed, denied, and error side-effect tool attempts.
- Added fail-closed behavior for write/execute tools when audit writer fails.
- Ensured read tools are not blocked by audit writer failure.
- Reused NEW-04 redaction helpers for bounded safe argument previews.
- Documented AUDIT_LOG_PATH and production behavior in .env.example, README.md, and docs/api.md.

Verification

- uv run ruff check core/src services/api-gateway/src services/api-gateway/tests mcp/src mcp/tests: OK
- uv run ruff format --check core/src services/api-gateway/src services/api-gateway/tests mcp/src mcp/tests: OK
- targeted audit/startup/registry tests: 57 passed
- uv run pytest -q services/api-gateway/tests mcp/tests: 364 passed
- uv run python scripts/license_headers.py --check: OK
- uv run mypy services/api-gateway/src/runtime/audit.py services/api-gateway/src/runtime/registry.py services/api-gateway/src/gateway/main.py:
  - no cache crash after rm -rf .mypy_cache
  - only pre-existing opentelemetry.trace attr-defined baseline remains

Scope

Not changed:

- RBAC #016 semantics
- OIDC/JWKS #009
- NEW-04 redaction/egress design
- OPA/schema-hash #028
- Admin API contract / OpenAPI
- Java ticket adapter internals
- real NATS/JetStream/Kubernetes/cloud dependency in CI

Design note

This PR implements the API Gateway side-effect audit enforcement point. The broader JetStream durable consumer / DLQ / idempotency auditor-service rescope remains separate work.
