### PR TITLE
Enforce side-effect policy fail-closed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,22 @@ ENVIRONMENT=dev
 # Event bus address shared by the API gateway and the auditor stream processor.
 NATS_URL=nats://localhost:4222
 
+# ISSUE 028 fail-closed policy choke point (services/api-gateway/src/runtime/policy_enforcer.py).
+# POLICY_MODE selects the enforcer: 'opa' (real OPA server, any tier), 'local'
+# (deterministic allow-all; refused on a deployed tier), or unset (safe
+# default — deployed tiers require OPA, same fail-closed default as
+# ENVIRONMENT above; non-deployed tiers use the local mode).
+POLICY_MODE=
+
 # Open Policy Agent URL used by the API gateway for authorization decisions.
+# Required (and startup aborts if missing) whenever POLICY_MODE=opa, or on a
+# deployed tier under the default POLICY_MODE.
 OPA_URL=http://localhost:8181
+# Rego data path queried for the allow decision (POST {OPA_URL}/v1/data/{path}).
+OPA_POLICY_PATH=astradesk/tools/allow
+# Per-request timeout (seconds) for the OPA policy check; a timeout is a
+# fail-closed deny, not a fail-open allow.
+OPA_TIMEOUT_SECONDS=2.0
 
 # LLM provider selector for services/api-gateway (openai | bedrock | vllm).
 MODEL_PROVIDER=openai

--- a/README.md
+++ b/README.md
@@ -1080,6 +1080,7 @@ symlink to the canonical spec so the UI never drifts.
 - **RBAC**: Per tool, based on claims.
 - **mTLS**: STRICT via Istio.
 - **Audit**: Logged to Postgres + NATS publish. Every `write`/`execute` tool attempt (allowed, denied, or errored) is additionally recorded through a durable `AuditWriter` at the `ToolRegistry.execute` choke point, on both the LLM-planned and keyword-fallback paths. Deployed tiers (`production`/`prod`/`staging`/`stage`) fail closed at startup without `AUDIT_LOG_PATH`; local/dev/test may fall back to a non-durable in-process writer.
+- **Policy (OPA, fail-closed)**: A contextual policy gate, independent of RBAC, additionally guards every `write`/`execute` tool attempt (and any `read` tool opted in with `policy_governed=True`) at the same `ToolRegistry.execute` choke point (`runtime.policy_enforcer`, ISSUE 028). Deployed tiers require a real OPA server (`POLICY_MODE=opa` or the safe default) — missing/invalid `OPA_URL` aborts startup, and a denied or unreachable OPA decision at call time denies the tool before it runs. `POLICY_MODE=local` (deterministic allow-all) is refused on deployed tiers. Policy denials are durably audited through the same ISSUE 019 path. Schema-hash negotiation and OPA bundle versioning remain future work (Track B).
 - **Policies**: Allow-lists in tools, proxy retries.
 
 ## Roadmap
@@ -1087,7 +1088,8 @@ symlink to the canonical spec so the UI never drifts.
 - LLM integration (Bedrock/OpenAI/vLLM) with guardrails.
 - Temporal for long-running workflows.
 - RAG evaluations (Ragas).
-- Advanced multi-tenancy & RBAC (OPA).
+- Advanced multi-tenancy.
+- OPA policy-bundle supply chain: schema-hash negotiation and bundle versioning (see `docs/roadmap/issues/ISSUES_028_opa_fail_closed.md`).
 - Full Grafana dashboards with alerts.
 
 ## Contributing

--- a/docs/roadmap/issues/ISSUES_028_opa_fail_closed.md
+++ b/docs/roadmap/issues/ISSUES_028_opa_fail_closed.md
@@ -50,14 +50,20 @@ Early MCP/tool ecosystems suffered tool-poisoning (a tool's declared schema/desc
 | Bundle version unknown | Deny until a valid versioned bundle loads |
 
 ## Acceptance criteria (Definition of Done)
-- [ ] OPA deployed and health-gated; bundle versioned.
-- [ ] Bypass test: OPA down → side effects denied, not allowed.
-- [ ] Dual-path test: fallback tool call is policy-checked identically.
-- [ ] Schema-hash negotiation enforced; mismatch rejected with audit of both hashes.
-- [ ] Decision + bundle version present in audit records.
+- [x] Policy check moved to the shared `ToolRegistry.execute` choke point (ISSUE 016), so fallback and LLM-planned calls are covered identically.
+- [x] Bypass test: OPA down/unreachable/timeout/ambiguous decision → side effects denied, not allowed (`services/api-gateway/tests/runtime/test_policy_enforcer.py`, `test_policy_choke_point.py`).
+- [x] Dual-path test: fallback tool call is policy-checked identically to the LLM-planned call (`test_policy_choke_point.py::test_dual_path_*`).
+- [x] Deployed-tier fail-closed startup: missing/invalid OPA config aborts process start (`test_policy_startup.py`, `test_policy_enforcer.py::test_deployed_tier_without_opa_url_fails_closed`).
+- [x] Policy denials durably audited through the ISSUE 019 path (`test_policy_choke_point.py::test_policy_denial_emits_durable_audit_event`).
+- [ ] OPA deployed as a tracked workload (sidecar/deployment) + bundle directory; health-gated at the infra level. *(Not implemented here — this issue delivered the application-level enforcer/choke-point/fail-closed contract; standing up the OPA workload itself is a deployment/ops task tracked separately.)*
+- [ ] Policy bundles versioned; bundle version recorded in the audit decision (`INV-OPA-3`). *(Deferred — no bundle-versioning scheme exists yet; out of scope per the rescope below.)*
+- [ ] Schema-hash negotiation enforced; mismatch rejected with audit of both hashes (`INV-SCHEMA-1`). *(Deferred — Track B, see below.)*
 
 ## Verification evidence (artifact)
-OPA-down bypass test log; schema-mismatch rejection test; dual-path policy test.
+`uv run pytest -q services/api-gateway/tests/runtime/test_policy_enforcer.py services/api-gateway/tests/runtime/test_policy_choke_point.py services/api-gateway/tests/runtime/test_policy_startup.py` — OPA-down/timeout/ambiguous-decision fail-closed tests, dual-path policy test, deployed-tier startup fail-closed tests, and durable-audit-of-denial tests.
+
+## Rescope note (v0.3.1 Safety Core)
+Per the Safety Core priority order (CLAUDE.md §19), this pass delivered the deployable, fail-closed, dual-path policy *enforcement contract* at the `ToolRegistry.execute` choke point (`services/api-gateway/src/runtime/policy_enforcer.py`): a `PolicyEnforcer` protocol, a deterministic `LocalPolicyEnforcer` (explicit non-deployed-tier mode), a fail-closed `OpaHttpPolicyEnforcer`, and `build_policy_enforcer_from_env` (fail-closed tier/mode selection, mirroring ISSUE 009/019). Schema-hash negotiation, OPA bundle versioning/supply chain, and AstraCatalog policy versioning were **not** implemented — these remain Track B per the engineering task's non-goals and are tracked as open items above.
 
 ## Out of scope
-Rich policy authoring UX, policy simulation/CI policy tests as a separate suite (Track B).
+Rich policy authoring UX, policy simulation/CI policy tests as a separate suite, OPA bundle supply chain, schema-hash negotiation, AstraCatalog policy versioning (Track B).

--- a/services/api-gateway/src/gateway/main.py
+++ b/services/api-gateway/src/gateway/main.py
@@ -52,6 +52,7 @@ from runtime.authz import SideEffect, enforce_registration_invariants
 from runtime.memory import Memory
 from runtime.models import AgentRequest, AgentResponse
 from runtime.planner import KeywordPlanner
+from runtime.policy_enforcer import PolicyEnforcer, build_policy_enforcer_from_env
 from runtime.rag import RAG
 from runtime.registry import ToolRegistry, load_domain_packs
 from tools import metrics, ops_actions, tickets_proxy
@@ -141,6 +142,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # deployed tier without a durable audit sink must never start, mirroring
     # how the OIDC verifier above already aborts before DB/Redis are touched.
     audit_writer = _resolve_audit_writer()
+    # Fail-closed before any external resource is touched (ISSUE 028): a
+    # deployed tier without valid policy (OPA) configuration must never
+    # start, mirroring the audit sink and OIDC verifier checks above.
+    policy_enforcer: PolicyEnforcer = build_policy_enforcer_from_env()
+    app_state['policy_enforcer'] = policy_enforcer
 
     # --- Initialize connections ---
     # DATABASE_URL/REDIS_URL always resolve (to real values or safe dummy
@@ -159,9 +165,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     opa_client = OpaClient(url=OPA_URL)
 
     # --- Initialize core components ---
-    # audit_writer was already resolved fail-closed above, before any
-    # external resource was touched.
-    tool_registry = ToolRegistry(audit_writer=audit_writer)
+    # audit_writer/policy_enforcer were already resolved fail-closed above,
+    # before any external resource was touched.
+    tool_registry = ToolRegistry(audit_writer=audit_writer, policy_enforcer=policy_enforcer)
     # Register built-in tools with mandatory RBAC metadata (ISSUE 016).
     # side_effect + allowed_roles are the source of truth for the choke point;
     # the OIDC layer normalizes identity/roles, RBAC authorizes from those roles.
@@ -241,6 +247,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     if 'admin_api_client' in app_state:
         await app_state['admin_api_client'].aclose()
         logger.info('Admin API client shut down.')
+
+    if 'policy_enforcer' in app_state:
+        aclose = getattr(app_state['policy_enforcer'], 'aclose', None)
+        if callable(aclose):
+            await aclose()
 
     logger.info('Resources cleaned up.')
 

--- a/services/api-gateway/src/runtime/policy_enforcer.py
+++ b/services/api-gateway/src/runtime/policy_enforcer.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/src/runtime/policy_enforcer.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Implements AstraDesk functionality for services/api-gateway/src/runtime/policy_enforcer.py.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Deployable, fail-closed contextual policy enforcement (ISSUE 028).
+
+This module adds a second, independent governance gate to the single tool
+invocation choke point already established by RBAC (ISSUE 016,
+:mod:`runtime.authz`) and durable audit (ISSUE 019, :mod:`runtime.audit`) in
+:meth:`runtime.registry.ToolRegistry.execute`. RBAC answers *who may execute
+this class of tool*; this module answers *does external policy (OPA/Rego)
+additionally permit this specific attempt right now*. Neither replaces the
+other, and neither is duplicated here (``INV-DUAL-PATH`` composition, not
+redesign).
+
+Target invariants (ISSUE 028)
+------------------------------
+- ``INV-POLICY-1``: every attempted ``write``/``execute`` tool call passes
+  through :class:`PolicyEnforcer.evaluate`.
+- ``INV-POLICY-2``: the LLM-planned and keyword-fallback paths reach the same
+  enforcement point identically, because both call
+  :meth:`runtime.registry.ToolRegistry.execute` (``INV-DUAL-PATH``).
+- ``INV-POLICY-3``: a denial (``PolicyDecision.allow is False``) raises
+  :class:`PolicyDenied` before the tool function runs.
+- ``INV-POLICY-4``/``INV-POLICY-5``: on a deployed tier (``production``,
+  ``prod``, ``staging``, ``stage`` — ``ENVIRONMENT`` unset defaults to
+  ``production``, mirroring :func:`astradesk_core.utils.oidc.build_verifier_from_env`
+  and ``gateway.main._resolve_audit_writer``), missing/invalid OPA
+  configuration aborts startup (:class:`PolicyConfigError`), and an OPA
+  request that fails/times out/returns an ambiguous decision at call time
+  denies rather than allows.
+- ``INV-POLICY-6``: ``read`` tools are only policy-checked when a tool is
+  explicitly registered with ``policy_governed=True``
+  (:data:`runtime.registry.ToolInfo.policy_governed`); by default a broken
+  policy dependency can never block a plain read.
+- ``INV-POLICY-8``: the request built for the enforcer
+  (:class:`PolicyRequest`) carries only normalized/redacted/bounded fields —
+  the same safe fields already computed for the ISSUE 019 audit event, reused
+  here rather than re-derived from raw kwargs/claims.
+- ``INV-POLICY-9``: roles/subject are the already-normalized values RBAC uses
+  (:mod:`runtime.authz`), never raw IdP claim shapes.
+- ``INV-POLICY-10``: :class:`LocalPolicyEnforcer` is deterministic and
+  dependency-free; :class:`OpaHttpPolicyEnforcer` accepts an injectable HTTP
+  client so unit tests never require a real OPA server.
+- ``INV-LOCAL-MODE-EXPLICIT``: the permissive local mode is reachable only via
+  an explicit, non-default ``POLICY_MODE=local`` (or the safe non-deployed-tier
+  default) and is refused on a deployed tier.
+
+Design
+------
+:class:`PolicyEnforcer` is a minimal structural protocol (``async def
+evaluate(request) -> PolicyDecision``), mirroring :class:`runtime.audit.AuditWriter`.
+Two implementations are provided:
+
+- :class:`LocalPolicyEnforcer` — deterministic allow-all. The safe default for
+  :class:`~runtime.registry.ToolRegistry` (so existing callers/tests that do
+  not configure an explicit enforcer keep working unchanged, exactly like
+  :class:`runtime.audit.InMemoryAuditWriter`) and the explicit mode for
+  ``development``/``dev``/``test``/``local``/``ci`` tiers.
+- :class:`OpaHttpPolicyEnforcer` — calls a real OPA server's Data API
+  (``POST {OPA_URL}/v1/data/{policy_path}``) over HTTP. Fail-closed on any
+  transport error, timeout, non-2xx response, or a decision that is not
+  unambiguously boolean.
+
+:func:`build_policy_enforcer_from_env` selects between them at startup,
+fail-closed, mirroring :func:`astradesk_core.utils.oidc.build_verifier_from_env`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+import httpx
+
+if TYPE_CHECKING:
+    from runtime.authz import SideEffect
+
+__all__ = [
+    'LocalPolicyEnforcer',
+    'OpaHttpPolicyEnforcer',
+    'PolicyConfigError',
+    'PolicyDecision',
+    'PolicyDenied',
+    'PolicyEnforcer',
+    'PolicyReason',
+    'PolicyRequest',
+    'build_policy_enforcer_from_env',
+]
+
+logger = logging.getLogger(__name__)
+
+# Tiers on which the permissive local policy mode must never be reachable —
+# the same values used by astradesk_core.utils.oidc._DEPLOYED_TIERS and
+# gateway.main._AUDIT_DEPLOYED_TIERS, kept local rather than importing either
+# module's private constant for an unrelated concern.
+_POLICY_DEPLOYED_TIERS = frozenset({'production', 'prod', 'staging', 'stage'})
+
+_DEFAULT_POLICY_PATH = 'astradesk/tools/allow'
+_DEFAULT_TIMEOUT_SECONDS = 2.0
+
+
+class PolicyReason(str, Enum):
+    """Stable, audit-friendly reason codes for a policy denial."""
+
+    DENIED = 'POLICY_DENIED'
+    UNAVAILABLE = 'POLICY_UNAVAILABLE'
+
+
+class PolicyConfigError(RuntimeError):
+    """Raised at startup when policy configuration is missing/invalid.
+
+    Surfacing this aborts process start (fail-closed), mirroring
+    :class:`astradesk_core.utils.oidc.AuthConfigError` and
+    ``gateway.main.AuditConfigError``. It must never be caught and downgraded
+    to a permissive default.
+    """
+
+
+class PolicyDenied(PermissionError):
+    """Raised when the policy choke point denies a tool invocation.
+
+    Carries only the tool name and a stable reason code (either a synthetic
+    :class:`PolicyReason` or a short reason string returned by the enforcer
+    itself, e.g. a Rego ``deny`` message) — never raw payload, claims, or
+    secrets.
+    """
+
+    def __init__(self, reason: str, tool: str) -> None:
+        self.reason = reason
+        self.tool = tool
+        super().__init__(f"Access denied for tool '{tool}' [{reason}]")
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyRequest:
+    """Bounded, redacted input to a policy decision (``INV-POLICY-8``/``-9``).
+
+    Every field is either a stable identifier, normalized role data, or a
+    value that already passed through the shared NEW-04 redaction/bounding
+    boundary via :func:`runtime.audit.build_args_preview`. Nothing here may
+    carry a raw token, Authorization header, secret, private key, raw PII, or
+    an unbounded argument payload.
+    """
+
+    tool: str
+    side_effect: SideEffect
+    roles: tuple[str, ...] = ()
+    principal_id: str | None = None
+    tenant_id: str | None = None
+    trace_id: str | None = None
+    request_id: str | None = None
+    approval_id: str | None = None
+    args_preview: dict[str, Any] = field(default_factory=dict)
+
+    def to_input(self) -> dict[str, Any]:
+        """Render as the ``input`` document sent to an external policy engine."""
+        return {
+            'tool': {'name': self.tool, 'side_effect': self.side_effect.value},
+            'auth': {'roles': list(self.roles), 'principal_id': self.principal_id},
+            'context': {
+                'tenant_id': self.tenant_id,
+                'trace_id': self.trace_id,
+                'request_id': self.request_id,
+                'approval_id': self.approval_id,
+            },
+            'args_preview': self.args_preview,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDecision:
+    """The outcome of one policy evaluation."""
+
+    allow: bool
+    reason: str | None = None
+
+
+@runtime_checkable
+class PolicyEnforcer(Protocol):
+    """Structural contract for the ISSUE 028 policy choke point."""
+
+    async def evaluate(self, request: PolicyRequest) -> PolicyDecision:
+        """Decide ``request``. Must not raise for an ordinary deny — return
+        ``PolicyDecision(allow=False, ...)`` instead. Raising is reserved for
+        truly unexpected errors, which the caller treats as fail-closed."""
+        ...
+
+
+class LocalPolicyEnforcer:
+    """Deterministic, dependency-free enforcer: always allows.
+
+    The explicit, non-default local/dev/test/ci mode (``INV-LOCAL-MODE-EXPLICIT``)
+    and the safe default for :class:`~runtime.registry.ToolRegistry` when no
+    enforcer is configured. It never weakens RBAC, approval, or audit — those
+    remain fully enforced at the same choke point regardless of the policy
+    decision (``INV-POLICY-*`` compose with, never replace, ISSUE 016/019).
+    """
+
+    async def evaluate(self, request: PolicyRequest) -> PolicyDecision:
+        return PolicyDecision(allow=True)
+
+
+class OpaHttpPolicyEnforcer:
+    """Fail-closed HTTP enforcer backed by a real OPA server's Data API.
+
+    Queries ``POST {base_url}/v1/data/{policy_path}`` with ``{"input": ...}``
+    and expects a decision shaped as ``{"result": {"allow": bool, ...}}`` or
+    ``{"result": bool}``. Any transport error, timeout, non-2xx response, or a
+    ``result`` that is not unambiguously boolean is treated as an unavailable
+    decision and denies (``INV-OPA-1``/``INV-FAIL-CLOSED``) — this method
+    never raises for those cases, so the registry choke point cannot
+    accidentally fail open on an uncaught exception.
+
+    An HTTP client can be injected (``client``) so unit tests exercise this
+    class against ``httpx.MockTransport`` — no real OPA server is required in
+    CI (``INV-POLICY-10``).
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        policy_path: str = _DEFAULT_POLICY_PATH,
+        timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._url = f'{base_url.rstrip("/")}/v1/data/{policy_path.strip("/").replace(".", "/")}'
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(timeout=timeout)
+
+    async def evaluate(self, request: PolicyRequest) -> PolicyDecision:
+        try:
+            response = await self._client.post(self._url, json={'input': request.to_input()})
+            response.raise_for_status()
+            data = response.json()
+        except Exception as exc:
+            logger.warning(
+                "OPA policy check unavailable for tool='%s': %s",
+                request.tool,
+                type(exc).__name__,
+            )
+            return PolicyDecision(allow=False, reason=PolicyReason.UNAVAILABLE.value)
+
+        result = data.get('result') if isinstance(data, dict) else None
+        allow = result.get('allow') if isinstance(result, dict) else result
+        if not isinstance(allow, bool):
+            logger.warning(
+                "OPA policy decision ambiguous for tool='%s': result=%r", request.tool, result
+            )
+            return PolicyDecision(allow=False, reason=PolicyReason.UNAVAILABLE.value)
+
+        reason = None
+        if not allow and isinstance(result, dict):
+            raw_reason = result.get('reason')
+            reason = str(raw_reason)[:200] if raw_reason else None
+        return PolicyDecision(
+            allow=allow, reason=reason or (None if allow else PolicyReason.DENIED.value)
+        )
+
+    async def aclose(self) -> None:
+        """Release the owned HTTP client (no-op for an injected client)."""
+        if self._owns_client:
+            await self._client.aclose()
+
+
+def _opa_enforcer_from_env() -> OpaHttpPolicyEnforcer:
+    """Build the OPA enforcer from environment, fail-closed on missing config."""
+    base_url = os.getenv('OPA_URL', '').strip()
+    if not base_url:
+        raise PolicyConfigError(
+            'OPA_URL is required to build the OPA policy enforcer on this tier.'
+        )
+    policy_path = os.getenv('OPA_POLICY_PATH', '').strip() or _DEFAULT_POLICY_PATH
+    try:
+        timeout = float(os.getenv('OPA_TIMEOUT_SECONDS', str(_DEFAULT_TIMEOUT_SECONDS)))
+    except ValueError as exc:
+        raise PolicyConfigError('OPA_TIMEOUT_SECONDS must be a number') from exc
+    return OpaHttpPolicyEnforcer(base_url=base_url, policy_path=policy_path, timeout=timeout)
+
+
+def build_policy_enforcer_from_env() -> PolicyEnforcer:
+    """Construct the ISSUE 028 policy enforcer from environment, fail-closed.
+
+    ``POLICY_MODE`` (optional):
+      - ``local``: explicit local mode. Refused (:class:`PolicyConfigError`) on
+        a deployed tier (``INV-LOCAL-MODE-EXPLICIT``).
+      - ``opa``: builds :class:`OpaHttpPolicyEnforcer` from ``OPA_URL`` (and
+        optional ``OPA_POLICY_PATH``/``OPA_TIMEOUT_SECONDS``), regardless of
+        tier. Missing/invalid config aborts startup.
+      - unset: safe default — deployed tiers require OPA (same fail-closed
+        default as :func:`astradesk_core.utils.oidc.build_verifier_from_env`
+        and ``gateway.main._resolve_audit_writer``: ``ENVIRONMENT`` unset
+        behaves like ``production``); non-deployed tiers get
+        :class:`LocalPolicyEnforcer`.
+      - any other value: aborts startup.
+    """
+    mode = os.getenv('POLICY_MODE', '').strip().lower()
+    environment = os.getenv('ENVIRONMENT', 'production').strip().lower()
+    deployed = environment in _POLICY_DEPLOYED_TIERS
+
+    if mode == 'local':
+        if deployed:
+            raise PolicyConfigError(f"POLICY_MODE=local is forbidden on tier '{environment}'")
+        return LocalPolicyEnforcer()
+
+    if mode == 'opa':
+        return _opa_enforcer_from_env()
+
+    if mode:
+        raise PolicyConfigError(f'unknown POLICY_MODE: {mode!r}')
+
+    if deployed:
+        return _opa_enforcer_from_env()
+    return LocalPolicyEnforcer()

--- a/services/api-gateway/src/runtime/registry.py
+++ b/services/api-gateway/src/runtime/registry.py
@@ -30,6 +30,12 @@ Overview
   so the LLM-planned and keyword-fallback paths enforce identically
   (`INV-DUAL-PATH`). `side_effect` is mandatory at registration; a `write`/
   `execute` tool without `allowed_roles` is rejected at registration (fail fast).
+- Fail-closed contextual policy choke point (ISSUE 028): after RBAC passes,
+  `execute()` additionally consults a `runtime.policy_enforcer.PolicyEnforcer`
+  for every `write`/`execute` attempt (and any `read` tool explicitly
+  registered with `policy_governed=True`). A denial or an unavailable policy
+  dependency raises `PolicyDenied` before the tool runs; RBAC is not
+  duplicated by this gate, only composed with it.
 - Unified execution: async callables awaited directly; sync callables executed
   via `asyncio.to_thread`, with exceptions logged and re-raised.
 - Domain Packs: discoverable through `importlib.metadata.entry_points(group="astradesk.pack")`;
@@ -116,6 +122,7 @@ from typing import Any
 __all__ = [
     'AuditWriteError',
     'AuthorizationError',
+    'PolicyDenied',
     'RbacDenied',
     'SideEffect',
     'ToolInfo',
@@ -155,6 +162,14 @@ from runtime.authz import (
 )
 from runtime.authz import (
     SIDE_EFFECTING as _SIDE_EFFECTING,
+)
+from runtime.policy_enforcer import (
+    LocalPolicyEnforcer,
+    PolicyDecision,
+    PolicyDenied,
+    PolicyEnforcer,
+    PolicyReason,
+    PolicyRequest,
 )
 
 # Logowanie
@@ -236,6 +251,9 @@ class ToolInfo:
     allowed_roles: set[str] = field(default_factory=set)
     requires_approval: bool = False
     schema: dict[str, Any] = field(default_factory=dict)
+    # ISSUE 028: opt-in policy governance for a `read` tool. `write`/`execute`
+    # tools are always policy-governed regardless of this flag.
+    policy_governed: bool = False
 
     # Cache techniczny - nie eksponujemy w repr, ustawiany podczas register()
     signature: inspect.Signature | None = field(default=None, repr=False)
@@ -252,6 +270,7 @@ class ToolRegistry:
         audit_writer: AuditWriter | None = None,
         audit_event_id: EventIdFn = default_event_id,
         audit_clock: ClockFn = default_clock,
+        policy_enforcer: PolicyEnforcer | None = None,
     ) -> None:
         """Inicjalizacja klasa.
 
@@ -265,6 +284,14 @@ class ToolRegistry:
                 override in tests for deterministic ids.
             audit_clock: Injectable UTC clock (``INV-AUDIT-7``); override in
                 tests for deterministic timestamps.
+            policy_enforcer: Contextual policy gate (ISSUE 028) consulted for
+                every ``write``/``execute`` attempt (and any ``read`` tool
+                registered with ``policy_governed=True``). Defaults to
+                :class:`~runtime.policy_enforcer.LocalPolicyEnforcer`, a
+                deterministic allow-all, so existing callers/tests that do not
+                configure an enforcer keep working unchanged — exactly like
+                the default audit writer. Production wiring should inject
+                :func:`~runtime.policy_enforcer.build_policy_enforcer_from_env`.
 
         """
         self._tools: dict[str, ToolInfo] = {}
@@ -272,6 +299,7 @@ class ToolRegistry:
         self._audit_writer: AuditWriter = audit_writer or InMemoryAuditWriter()
         self._audit_event_id = audit_event_id
         self._audit_clock = audit_clock
+        self._policy_enforcer: PolicyEnforcer = policy_enforcer or LocalPolicyEnforcer()
 
     # Mutacje
     async def register(
@@ -285,6 +313,7 @@ class ToolRegistry:
         allowed_roles: set[str] | None = None,
         requires_approval: bool = False,
         schema: dict[str, Any] | None = None,
+        policy_governed: bool = False,
         override: bool = False,
     ) -> None:
         """Rejestruje narzędzie; użyj override=True aby zastąpić istniejące.
@@ -298,6 +327,13 @@ class ToolRegistry:
             the approval/change-record gate (``INV-RBAC-4``). All invariants are
             enforced here so a mis-declared tool fails fast at boot, not at the
             first unauthorized call (``INV-FAIL-CLOSED``).
+
+        Policy metadata (ISSUE 028):
+            ``write``/``execute`` tools are always policy-governed. Set
+            ``policy_governed=True`` to additionally subject a ``read`` tool to
+            the same contextual policy check (``INV-POLICY-6``); it is ``False``
+            by default so a broken policy dependency can never block an
+            ordinary read.
 
         Raises:
             ToolRegistrationError: niepoprawna nazwa/funkcja, brakujące lub
@@ -331,6 +367,7 @@ class ToolRegistry:
             allowed_roles=roles,
             requires_approval=effective_requires_approval,
             schema=dict(schema or {}),
+            policy_governed=bool(policy_governed),
         )
 
         # Cache sygnatury i coroutine-ness (tu, zamiast robić to w hot-path execute()).
@@ -486,6 +523,53 @@ class ToolRegistry:
                 await emit(AuditDecision.ERROR, error_type=type(exc).__name__, fail_closed=False)
             raise
 
+    async def _enforce_policy(
+        self,
+        *,
+        name: str,
+        info: ToolInfo,
+        shared_fields: dict[str, Any],
+        trace_id: str | None,
+        request_id: str | None,
+        approval_id: str | None,
+        is_side_effecting: bool,
+        emit: Callable[..., Any],
+    ) -> None:
+        """Contextual policy choke point (ISSUE 028; ``INV-POLICY-1..6``).
+
+        Called after RBAC passes, before any pre-execution audit write, so a
+        policy deny or an unavailable policy dependency prevents the tool from
+        running exactly like an RBAC deny. Never duplicates RBAC's role
+        decision — this gate answers external/contextual governance only.
+
+        Raises:
+            PolicyDenied: on a deny decision or an unavailable/ambiguous
+                policy dependency (fail-closed).
+        """
+        policy_request = PolicyRequest(
+            tool=name,
+            side_effect=info.side_effect,
+            roles=shared_fields['roles'],
+            principal_id=shared_fields['principal_id'],
+            tenant_id=shared_fields['tenant_id'],
+            trace_id=trace_id,
+            request_id=request_id,
+            approval_id=approval_id,
+            args_preview=shared_fields['args_preview'],
+        )
+        try:
+            decision = await self._policy_enforcer.evaluate(policy_request)
+        except Exception as exc:  # fail-closed backstop: never fail open
+            _logger.warning("Policy enforcer raised for tool='%s': %s", name, type(exc).__name__)
+            decision = PolicyDecision(allow=False, reason=PolicyReason.UNAVAILABLE.value)
+
+        if not decision.allow:
+            reason = decision.reason or PolicyReason.DENIED.value
+            _logger.warning("Policy deny: tool='%s' reason=%s", name, reason)
+            if is_side_effecting:
+                await emit(AuditDecision.DENIED, reason=reason, fail_closed=True)
+            raise PolicyDenied(reason, name)
+
     # Wykonanie
     async def execute(
         self,
@@ -499,14 +583,22 @@ class ToolRegistry:
         principal_id: str | None = None,
         **kwargs: Any,
     ) -> Any:
-        """Uruchamia narzędzie — jedyny punkt egzekwowania RBAC (ISSUE 016)
-        i durable audytu dla narzędzi side-effecting (ISSUE 019).
+        """Uruchamia narzędzie — jedyny punkt egzekwowania RBAC (ISSUE 016),
+        kontekstowej polityki (ISSUE 028) i durable audytu dla narzędzi
+        side-effecting (ISSUE 019).
 
         This is the single authorization choke point that both the LLM-planned
-        and keyword-fallback paths traverse (``INV-DUAL-PATH``). The decision is
-        delegated to :func:`runtime.authz.authorize_tool` and made from
-        *normalized roles only*. For ``write``/``execute`` tools, every attempt
-        — denied, allowed, or erroring — is durably recorded through the
+        and keyword-fallback paths traverse (``INV-DUAL-PATH``). RBAC is
+        delegated to :func:`runtime.authz.authorize_tool` and decided from
+        *normalized roles only*; once RBAC passes, the same call additionally
+        consults the configured
+        :class:`~runtime.policy_enforcer.PolicyEnforcer` for ``write``/
+        ``execute`` tools (and any ``read`` tool registered with
+        ``policy_governed=True``) — a policy deny or unavailable dependency
+        raises :class:`~runtime.policy_enforcer.PolicyDenied` before the tool
+        runs (``INV-POLICY-1``/``INV-POLICY-3``/``INV-FAIL-CLOSED``). For
+        ``write``/``execute`` tools, every attempt — RBAC-denied,
+        policy-denied, allowed, or erroring — is durably recorded through the
         configured :class:`~runtime.audit.AuditWriter` before the caller
         observes the outcome (``INV-AUDIT-1``/``INV-AUDIT-2``). ``read`` tools
         never touch the audit writer, so a broken sink can never block a read
@@ -537,6 +629,8 @@ class ToolRegistry:
 
         Raises:
             RbacDenied: gdy wywołanie nie jest autoryzowane (przed wykonaniem fn).
+            PolicyDenied: gdy kontekstowa polityka (ISSUE 028) odmawia lub jest
+                niedostępna (przed wykonaniem fn; fail-closed).
             ToolNotFoundError: gdy narzędzie nie istnieje.
             AuditWriteError: gdy audyt narzędzia side-effecting nie mógł zostać
                 trwale zapisany (``write``/``execute`` fail-closed, ISSUE 019).
@@ -556,17 +650,23 @@ class ToolRegistry:
         # original invocation kwargs, *before* any RBAC decision or meta-kwarg
         # stripping — so DENIED/ALLOWED/ERROR events for the same call always
         # report identical roles/principal/tenant/args_preview regardless of
-        # what the tool's own signature does with ``claims``. Only computed
-        # for side-effecting tools; the read-tool path never touches this.
-        audit_fields: dict[str, Any] = {}
-        if is_side_effecting:
+        # what the tool's own signature does with ``claims``. Computed
+        # whenever the tool is audited (side-effecting) or policy-governed
+        # (ISSUE 028: side-effecting, always, or an explicitly opted-in read
+        # tool) — a plain, unconfigured read tool never touches either.
+        is_policy_governed = is_side_effecting or info.policy_governed
+        shared_fields: dict[str, Any] = {}
+        if is_policy_governed:
             claims = kwargs.get('claims')
-            audit_fields = {
+            shared_fields = {
                 'roles': tuple(sorted(normalize_roles(effective_roles))),
                 'tenant_id': tenant_id or tenant_from_claims(claims),
                 'principal_id': principal_id or principal_from_claims(claims),
                 'args_preview': build_args_preview(kwargs),
             }
+        # Audit (ISSUE 019) stays scoped strictly to side-effecting tools
+        # (INV-AUDIT-6): a policy-governed read tool is never audited.
+        audit_fields = shared_fields if is_side_effecting else {}
 
         async def _emit(decision: AuditDecision, *, fail_closed: bool, **overrides: Any) -> None:
             await self._emit_audit(
@@ -600,6 +700,19 @@ class ToolRegistry:
             if is_side_effecting:
                 await _emit(AuditDecision.DENIED, reason=exc.reason.value, fail_closed=True)
             raise
+
+        # 1b Contextual policy choke point (ISSUE 028; INV-POLICY-1..6).
+        if is_policy_governed:
+            await self._enforce_policy(
+                name=name,
+                info=info,
+                shared_fields=shared_fields,
+                trace_id=trace_id,
+                request_id=request_id,
+                approval_id=effective_approval_id,
+                is_side_effecting=is_side_effecting,
+                emit=_emit,
+            )
 
         # 2 Czyszczenie kwargs: meta keys ('claims' and the approval fields) are
         #    stripped when the callable does not declare them, so they never leak

--- a/services/api-gateway/tests/runtime/test_policy_choke_point.py
+++ b/services/api-gateway/tests/runtime/test_policy_choke_point.py
@@ -1,0 +1,404 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/tests/runtime/test_policy_choke_point.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Verifies AstraDesk behavior for the associated component.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Policy choke-point tests for ToolRegistry.execute (ISSUE 028).
+
+Exercises the contextual policy gate wired into the single RBAC (ISSUE 016)
+and durable-audit (ISSUE 019) choke point. Both the LLM-planned and
+keyword-fallback paths call this exact method (see ``test_rbac_invariant.py``
+and ``test_audit.py``), so testing it here makes every side-effect attempt
+policy-checked regardless of caller (``INV-DUAL-PATH``). RBAC is not
+duplicated or weakened by these tests — they assert composition, not
+replacement.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from runtime.audit import AuditDecision, InMemoryAuditWriter
+from runtime.authz import RbacDenied, RbacReason, SideEffect
+from runtime.planner import KeywordPlanner
+from runtime.policy_enforcer import PolicyDecision, PolicyDenied, PolicyReason, PolicyRequest
+from runtime.registry import ToolRegistry
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Spy:
+    """Records whether the underlying tool function ran."""
+
+    def __init__(self) -> None:
+        self.called = False
+
+    def as_tool(self):
+        async def fn(*, service: str = '', **_: object) -> str:
+            self.called = True
+            return f'executed:{service}'
+
+        return fn
+
+
+class _RecordingEnforcer:
+    """Fake ``PolicyEnforcer`` that records every request it was asked to decide."""
+
+    def __init__(
+        self, *, decision: PolicyDecision | None = None, raises: Exception | None = None
+    ) -> None:
+        self.calls: list[PolicyRequest] = []
+        self._decision = decision or PolicyDecision(allow=True)
+        self._raises = raises
+
+    async def evaluate(self, request: PolicyRequest) -> PolicyDecision:
+        self.calls.append(request)
+        if self._raises is not None:
+            raise self._raises
+        return self._decision
+
+
+async def _register(
+    registry: ToolRegistry,
+    spy: _Spy,
+    *,
+    name: str = 'restart_service',
+    side_effect: SideEffect = SideEffect.EXECUTE,
+    allowed_roles: set[str] | None = None,
+    policy_governed: bool = False,
+) -> None:
+    await registry.register(
+        name,
+        spy.as_tool(),
+        side_effect=side_effect,
+        allowed_roles=allowed_roles if allowed_roles is not None else {'sre'},
+        policy_governed=policy_governed,
+    )
+
+
+# === 1 & 2. Successful write/execute call is policy-checked then invoked === #
+
+
+@pytest.mark.parametrize('side_effect', [SideEffect.WRITE, SideEffect.EXECUTE])
+async def test_successful_side_effect_call_is_policy_checked_and_invoked(
+    side_effect: SideEffect,
+) -> None:
+    enforcer = _RecordingEnforcer(decision=PolicyDecision(allow=True))
+    registry = ToolRegistry(policy_enforcer=enforcer)
+    spy = _Spy()
+    await _register(registry, spy, side_effect=side_effect)
+
+    result = await registry.execute(
+        'restart_service', roles=('sre',), approval_id='CHG-1001', service='webapp'
+    )
+
+    assert result == 'executed:webapp'
+    assert spy.called is True
+    assert len(enforcer.calls) == 1
+    assert enforcer.calls[0].tool == 'restart_service'
+    assert enforcer.calls[0].side_effect is side_effect
+
+
+# === 3 & 4. Policy denial blocks write/execute invocation ================== #
+
+
+@pytest.mark.parametrize('side_effect', [SideEffect.WRITE, SideEffect.EXECUTE])
+async def test_policy_denial_blocks_side_effect_invocation(side_effect: SideEffect) -> None:
+    enforcer = _RecordingEnforcer(decision=PolicyDecision(allow=False, reason='blocked_by_rule'))
+    registry = ToolRegistry(policy_enforcer=enforcer)
+    spy = _Spy()
+    await _register(registry, spy, side_effect=side_effect)
+
+    with pytest.raises(PolicyDenied) as excinfo:
+        await registry.execute(
+            'restart_service', roles=('sre',), approval_id='CHG-1001', service='webapp'
+        )
+
+    assert spy.called is False
+    assert excinfo.value.reason == 'blocked_by_rule'
+    assert excinfo.value.tool == 'restart_service'
+
+
+# === 5. Policy dependency failure blocks write/execute ====================== #
+
+
+@pytest.mark.parametrize('side_effect', [SideEffect.WRITE, SideEffect.EXECUTE])
+async def test_policy_dependency_failure_blocks_side_effect(side_effect: SideEffect) -> None:
+    enforcer = _RecordingEnforcer(raises=ConnectionError('opa unreachable'))
+    registry = ToolRegistry(policy_enforcer=enforcer)
+    spy = _Spy()
+    await _register(registry, spy, side_effect=side_effect)
+
+    with pytest.raises(PolicyDenied) as excinfo:
+        await registry.execute(
+            'restart_service', roles=('sre',), approval_id='CHG-1001', service='webapp'
+        )
+
+    assert spy.called is False
+    assert excinfo.value.reason == PolicyReason.UNAVAILABLE.value
+    # The underlying dependency error text must never leak into the exception.
+    assert 'opa unreachable' not in str(excinfo.value)
+
+
+# === 6. Policy dependency failure does not block an ordinary read tool ===== #
+
+
+async def test_policy_dependency_failure_does_not_block_unconfigured_read_tool() -> None:
+    enforcer = _RecordingEnforcer(raises=ConnectionError('opa unreachable'))
+    registry = ToolRegistry(policy_enforcer=enforcer)
+    spy = _Spy()
+    await registry.register('get_metrics', spy.as_tool(), side_effect=SideEffect.READ)
+
+    result = await registry.execute('get_metrics', roles=(), service='webapp')
+
+    assert result == 'executed:webapp'
+    assert spy.called is True
+    assert enforcer.calls == []  # policy is never even consulted for a plain read
+
+
+async def test_policy_dependency_failure_blocks_explicitly_governed_read_tool() -> None:
+    enforcer = _RecordingEnforcer(raises=ConnectionError('opa unreachable'))
+    registry = ToolRegistry(policy_enforcer=enforcer)
+    spy = _Spy()
+    await registry.register(
+        'get_metrics', spy.as_tool(), side_effect=SideEffect.READ, policy_governed=True
+    )
+
+    with pytest.raises(PolicyDenied):
+        await registry.execute('get_metrics', roles=(), service='webapp')
+
+    assert spy.called is False
+
+
+# === 9. LLM-planned and keyword-fallback paths hit the same enforcement === #
+
+
+async def _invoke_as_agent_path(
+    registry: ToolRegistry,
+    name: str,
+    roles: tuple[str, ...],
+    *,
+    approval_id: str | None = None,
+    **args: Any,
+) -> object:
+    """Mirror the exact call both runtime paths make to the choke point (see
+    ``test_rbac_invariant.py::_invoke_as_agent_path``)."""
+    return await registry.execute(name, roles=roles, approval_id=approval_id, claims={}, **args)
+
+
+@pytest.mark.parametrize('path', ['llm_planned', 'keyword_fallback'])
+async def test_dual_path_policy_denial_is_identical(path: str) -> None:
+    enforcer = _RecordingEnforcer(decision=PolicyDecision(allow=False, reason='ctx_blocked'))
+    registry = ToolRegistry(policy_enforcer=enforcer)
+    spy = _Spy()
+    await _register(registry, spy)
+
+    if path == 'keyword_fallback':
+        steps = KeywordPlanner().make_plan('please restart webapp now')
+        name, args = steps[0].name, steps[0].arguments
+    else:
+        name, args = 'restart_service', {'service': 'webapp'}
+
+    with pytest.raises(PolicyDenied) as excinfo:
+        await _invoke_as_agent_path(registry, name, ('sre',), approval_id='CHG-2002', **args)
+
+    assert excinfo.value.reason == 'ctx_blocked'
+    assert spy.called is False
+    assert len(enforcer.calls) == 1
+
+
+@pytest.mark.parametrize('path', ['llm_planned', 'keyword_fallback'])
+async def test_dual_path_policy_allow_executes(path: str) -> None:
+    enforcer = _RecordingEnforcer(decision=PolicyDecision(allow=True))
+    registry = ToolRegistry(policy_enforcer=enforcer)
+    spy = _Spy()
+    await _register(registry, spy)
+
+    if path == 'keyword_fallback':
+        steps = KeywordPlanner().make_plan('please restart webapp now')
+        name, args = steps[0].name, steps[0].arguments
+    else:
+        name, args = 'restart_service', {'service': 'webapp'}
+
+    result = await _invoke_as_agent_path(registry, name, ('sre',), approval_id='CHG-2003', **args)
+
+    assert result == 'executed:webapp'
+    assert len(enforcer.calls) == 1
+
+
+# === 10. Policy input uses normalized subject/roles, not raw claim shapes == #
+
+
+async def test_policy_request_uses_normalized_roles_and_safe_principal() -> None:
+    enforcer = _RecordingEnforcer(decision=PolicyDecision(allow=True))
+    registry = ToolRegistry(policy_enforcer=enforcer)
+    spy = _Spy()
+    await _register(registry, spy)
+
+    await registry.execute(
+        'restart_service',
+        roles=('SRE',),  # raw-cased input; normalized before policy sees it
+        approval_id='CHG-3001',
+        claims={'sub': 'user-42', 'tenant': 'acme-corp', 'realm_access': {'roles': ['SRE']}},
+        service='webapp',
+    )
+
+    request = enforcer.calls[0]
+    assert request.roles == ('sre',)
+    assert request.principal_id == 'user-42'
+    assert request.tenant_id == 'acme-corp'
+    # The raw claims container itself must never reach the policy request.
+    assert not hasattr(request, 'claims')
+
+
+# === 11 & 12. Policy input is redacted and bounded; no raw leak corpus ===== #
+
+
+async def test_policy_request_args_preview_is_redacted() -> None:
+    enforcer = _RecordingEnforcer(decision=PolicyDecision(allow=True))
+    registry = ToolRegistry(policy_enforcer=enforcer)
+    spy = _Spy()
+    await _register(registry, spy, name='create_ticket', side_effect=SideEffect.WRITE)
+
+    await registry.execute(
+        'create_ticket',
+        roles=('sre',),
+        approval_id='CHG-4001',
+        claims={'sub': 'user-1', 'access_token': 'super-secret-token-value'},
+        service='contact victim@example.com about ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345',
+    )
+
+    request = enforcer.calls[0]
+    rendered = str(request.args_preview)
+    assert 'victim@example.com' not in rendered
+    assert 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345' not in rendered
+    assert 'super-secret-token-value' not in rendered
+    assert 'access_token' not in rendered
+
+
+async def test_policy_request_args_preview_is_bounded() -> None:
+    enforcer = _RecordingEnforcer(decision=PolicyDecision(allow=True))
+    registry = ToolRegistry(policy_enforcer=enforcer)
+    spy = _Spy()
+    await _register(registry, spy, name='create_ticket', side_effect=SideEffect.WRITE)
+
+    huge_kwargs = {f'k{i}': 'x' * 5000 for i in range(50)}
+    await registry.execute('create_ticket', roles=('sre',), approval_id='CHG-4002', **huge_kwargs)
+
+    preview = enforcer.calls[0].args_preview
+    assert preview.get('_truncated') is True
+    assert len(preview) <= 21
+
+
+# === 13. Policy denial emits durable audit evidence (ISSUE 019 path) ======= #
+
+
+@pytest.mark.parametrize('side_effect', [SideEffect.WRITE, SideEffect.EXECUTE])
+async def test_policy_denial_emits_durable_audit_event(side_effect: SideEffect) -> None:
+    writer = InMemoryAuditWriter()
+    enforcer = _RecordingEnforcer(decision=PolicyDecision(allow=False, reason='ctx_blocked'))
+    registry = ToolRegistry(audit_writer=writer, policy_enforcer=enforcer)
+    spy = _Spy()
+    await _register(registry, spy, side_effect=side_effect)
+
+    with pytest.raises(PolicyDenied):
+        await registry.execute(
+            'restart_service', roles=('sre',), approval_id='CHG-5001', service='webapp'
+        )
+
+    assert len(writer.events) == 1
+    event = writer.events[0]
+    assert event.decision is AuditDecision.DENIED
+    assert event.reason == 'ctx_blocked'
+
+
+async def test_policy_dependency_failure_emits_durable_audit_event() -> None:
+    writer = InMemoryAuditWriter()
+    enforcer = _RecordingEnforcer(raises=RuntimeError('opa down'))
+    registry = ToolRegistry(audit_writer=writer, policy_enforcer=enforcer)
+    spy = _Spy()
+    await _register(registry, spy)
+
+    with pytest.raises(PolicyDenied):
+        await registry.execute(
+            'restart_service', roles=('sre',), approval_id='CHG-5002', service='webapp'
+        )
+
+    assert len(writer.events) == 1
+    assert writer.events[0].decision is AuditDecision.DENIED
+    assert writer.events[0].reason == PolicyReason.UNAVAILABLE.value
+    assert 'opa down' not in str(writer.events[0].to_dict())
+
+
+# === 14. RBAC denial still audited; RBAC is not weakened by policy ========= #
+
+
+async def test_rbac_denial_short_circuits_before_policy_is_consulted() -> None:
+    writer = InMemoryAuditWriter()
+    enforcer = _RecordingEnforcer(decision=PolicyDecision(allow=True))
+    registry = ToolRegistry(audit_writer=writer, policy_enforcer=enforcer)
+    spy = _Spy()
+    await _register(registry, spy)
+
+    with pytest.raises(RbacDenied) as excinfo:
+        await registry.execute('restart_service', roles=('viewer',), service='webapp')
+
+    assert excinfo.value.reason is RbacReason.ROLE_DENIED
+    assert spy.called is False
+    assert enforcer.calls == []  # policy is never reached once RBAC denies
+    assert len(writer.events) == 1
+    assert writer.events[0].decision is AuditDecision.DENIED
+    assert writer.events[0].reason == RbacReason.ROLE_DENIED.value
+
+
+# === 15. Missing approval/change record still denies and is audited ======= #
+
+
+async def test_missing_approval_denies_before_policy_and_is_audited() -> None:
+    writer = InMemoryAuditWriter()
+    enforcer = _RecordingEnforcer(decision=PolicyDecision(allow=True))
+    registry = ToolRegistry(audit_writer=writer, policy_enforcer=enforcer)
+    spy = _Spy()
+    await _register(registry, spy)
+
+    with pytest.raises(RbacDenied) as excinfo:
+        # Matching role, but no approval/change record (INV-RBAC-4).
+        await registry.execute('restart_service', roles=('sre',), service='webapp')
+
+    assert excinfo.value.reason is RbacReason.APPROVAL_REQUIRED
+    assert spy.called is False
+    assert enforcer.calls == []
+    assert len(writer.events) == 1
+    assert writer.events[0].reason == RbacReason.APPROVAL_REQUIRED.value
+
+
+# === Default wiring: unconfigured registry keeps existing behavior ========= #
+
+
+async def test_default_registry_without_explicit_enforcer_allows_side_effects() -> None:
+    """No policy_enforcer supplied -> LocalPolicyEnforcer default -> existing
+    RBAC-only behavior is fully preserved (RBAC #016 / audit #019 regression)."""
+    writer = InMemoryAuditWriter()
+    registry = ToolRegistry(audit_writer=writer)  # no policy_enforcer kwarg
+    spy = _Spy()
+    await _register(registry, spy)
+
+    result = await registry.execute(
+        'restart_service', roles=('sre',), approval_id='CHG-6001', service='webapp'
+    )
+
+    assert result == 'executed:webapp'
+    assert spy.called is True
+    assert len(writer.events) == 1
+    assert writer.events[0].decision is AuditDecision.ALLOWED

--- a/services/api-gateway/tests/runtime/test_policy_enforcer.py
+++ b/services/api-gateway/tests/runtime/test_policy_enforcer.py
@@ -1,0 +1,366 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/tests/runtime/test_policy_enforcer.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Verifies AstraDesk behavior for the associated component.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Tests for src/runtime/policy_enforcer.py (ISSUE 028 fail-closed policy).
+
+Covers:
+- LocalPolicyEnforcer: deterministic allow-all (explicit local/dev/test/ci mode).
+- OpaHttpPolicyEnforcer: allow/deny decisions, and fail-closed behavior on
+  transport errors, timeouts, non-2xx responses, and ambiguous decisions —
+  exercised against ``httpx.MockTransport`` so no real OPA server is required
+  (INV-POLICY-10).
+- PolicyRequest.to_input(): structurally cannot carry raw claims/tokens.
+- build_policy_enforcer_from_env(): the full fail-closed tier/mode matrix,
+  mirroring astradesk_core.utils.oidc.build_verifier_from_env and
+  gateway.main._resolve_audit_writer.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from runtime.authz import SideEffect
+from runtime.policy_enforcer import (
+    LocalPolicyEnforcer,
+    OpaHttpPolicyEnforcer,
+    PolicyConfigError,
+    PolicyReason,
+    PolicyRequest,
+    build_policy_enforcer_from_env,
+)
+
+# NOTE: no blanket `pytestmark = pytest.mark.asyncio` here — this module mixes
+# async (enforcer) and sync (factory-function) tests, and asyncio_mode="auto"
+# (root pyproject.toml) already detects async tests without a marker.
+
+
+def _request(**overrides: object) -> PolicyRequest:
+    defaults: dict[str, object] = {
+        'tool': 'restart_service',
+        'side_effect': SideEffect.EXECUTE,
+        'roles': ('sre',),
+        'principal_id': 'user-1',
+        'tenant_id': 'acme',
+        'trace_id': 'trace-1',
+        'request_id': 'req-1',
+        'approval_id': 'CHG-1001',
+        'args_preview': {'service': 'webapp'},
+    }
+    defaults.update(overrides)
+    return PolicyRequest(**defaults)  # type: ignore[arg-type]
+
+
+# === LocalPolicyEnforcer ===================================================== #
+
+
+async def test_local_policy_enforcer_always_allows() -> None:
+    enforcer = LocalPolicyEnforcer()
+    decision = await enforcer.evaluate(_request())
+    assert decision.allow is True
+    assert decision.reason is None
+
+
+# === PolicyRequest.to_input() shape ========================================= #
+
+
+def test_policy_request_to_input_carries_only_safe_fields() -> None:
+    request = _request()
+    payload = request.to_input()
+
+    assert payload['tool'] == {'name': 'restart_service', 'side_effect': 'execute'}
+    assert payload['auth'] == {'roles': ['sre'], 'principal_id': 'user-1'}
+    assert payload['context']['tenant_id'] == 'acme'
+    assert payload['context']['approval_id'] == 'CHG-1001'
+    assert payload['args_preview'] == {'service': 'webapp'}
+    # Structurally impossible to leak: there is no field for raw claims/token.
+    blob = str(payload)
+    assert 'claims' not in blob
+    assert 'token' not in blob
+    assert 'password' not in blob
+
+
+# === OpaHttpPolicyEnforcer: allow/deny decisions ============================ #
+
+
+def _client_with_handler(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+async def test_opa_enforcer_allows_on_boolean_true_result() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == '/v1/data/astradesk/tools/allow'
+        return httpx.Response(200, json={'result': True})
+
+    enforcer = OpaHttpPolicyEnforcer(
+        base_url='http://opa.local:8181', client=_client_with_handler(handler)
+    )
+    decision = await enforcer.evaluate(_request())
+    assert decision.allow is True
+
+
+async def test_opa_enforcer_allows_on_dict_allow_true() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={'result': {'allow': True}})
+
+    enforcer = OpaHttpPolicyEnforcer(
+        base_url='http://opa.local:8181', client=_client_with_handler(handler)
+    )
+    decision = await enforcer.evaluate(_request())
+    assert decision.allow is True
+
+
+async def test_opa_enforcer_denies_and_surfaces_reason() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={'result': {'allow': False, 'reason': 'no_capacity'}})
+
+    enforcer = OpaHttpPolicyEnforcer(
+        base_url='http://opa.local:8181', client=_client_with_handler(handler)
+    )
+    decision = await enforcer.evaluate(_request())
+    assert decision.allow is False
+    assert decision.reason == 'no_capacity'
+
+
+async def test_opa_enforcer_denies_without_reason_uses_stable_code() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={'result': False})
+
+    enforcer = OpaHttpPolicyEnforcer(
+        base_url='http://opa.local:8181', client=_client_with_handler(handler)
+    )
+    decision = await enforcer.evaluate(_request())
+    assert decision.allow is False
+    assert decision.reason == PolicyReason.DENIED.value
+
+
+async def test_opa_enforcer_sends_only_the_policy_request_shape() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        captured['body'] = json.loads(request.content)
+        return httpx.Response(200, json={'result': True})
+
+    enforcer = OpaHttpPolicyEnforcer(
+        base_url='http://opa.local:8181', client=_client_with_handler(handler)
+    )
+    await enforcer.evaluate(_request())
+
+    sent = captured['body']
+    assert sent == {'input': _request().to_input()}
+
+
+# === OpaHttpPolicyEnforcer: fail-closed behavior ============================ #
+
+
+async def test_opa_enforcer_fails_closed_on_connection_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('connection refused', request=request)
+
+    enforcer = OpaHttpPolicyEnforcer(
+        base_url='http://opa.local:8181', client=_client_with_handler(handler)
+    )
+    decision = await enforcer.evaluate(_request())
+    assert decision.allow is False
+    assert decision.reason == PolicyReason.UNAVAILABLE.value
+
+
+async def test_opa_enforcer_fails_closed_on_timeout() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout('timed out', request=request)
+
+    enforcer = OpaHttpPolicyEnforcer(
+        base_url='http://opa.local:8181', client=_client_with_handler(handler)
+    )
+    decision = await enforcer.evaluate(_request())
+    assert decision.allow is False
+    assert decision.reason == PolicyReason.UNAVAILABLE.value
+
+
+async def test_opa_enforcer_fails_closed_on_non_2xx_status() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={'error': 'internal'})
+
+    enforcer = OpaHttpPolicyEnforcer(
+        base_url='http://opa.local:8181', client=_client_with_handler(handler)
+    )
+    decision = await enforcer.evaluate(_request())
+    assert decision.allow is False
+    assert decision.reason == PolicyReason.UNAVAILABLE.value
+
+
+@pytest.mark.parametrize(
+    'body',
+    [
+        {'result': {}},
+        {'result': {'allow': 'yes'}},
+        {'result': None},
+        {},
+    ],
+)
+async def test_opa_enforcer_fails_closed_on_ambiguous_decision(body: dict[str, object]) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=body)
+
+    enforcer = OpaHttpPolicyEnforcer(
+        base_url='http://opa.local:8181', client=_client_with_handler(handler)
+    )
+    decision = await enforcer.evaluate(_request())
+    assert decision.allow is False
+    assert decision.reason == PolicyReason.UNAVAILABLE.value
+
+
+async def test_opa_enforcer_fails_closed_on_non_json_response() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b'not json')
+
+    enforcer = OpaHttpPolicyEnforcer(
+        base_url='http://opa.local:8181', client=_client_with_handler(handler)
+    )
+    decision = await enforcer.evaluate(_request())
+    assert decision.allow is False
+    assert decision.reason == PolicyReason.UNAVAILABLE.value
+
+
+async def test_opa_enforcer_custom_policy_path_used_in_url() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == '/v1/data/custom/pkg/allow'
+        return httpx.Response(200, json={'result': True})
+
+    enforcer = OpaHttpPolicyEnforcer(
+        base_url='http://opa.local:8181',
+        policy_path='custom.pkg.allow',
+        client=_client_with_handler(handler),
+    )
+    decision = await enforcer.evaluate(_request())
+    assert decision.allow is True
+
+
+async def test_opa_enforcer_aclose_closes_owned_client() -> None:
+    enforcer = OpaHttpPolicyEnforcer(base_url='http://opa.local:8181')  # no client injected
+    assert enforcer._client.is_closed is False
+    await enforcer.aclose()
+    assert enforcer._client.is_closed is True
+
+
+async def test_opa_enforcer_aclose_is_noop_for_injected_client() -> None:
+    client = _client_with_handler(lambda r: httpx.Response(200, json={'result': True}))
+    enforcer = OpaHttpPolicyEnforcer(base_url='http://opa.local:8181', client=client)
+    await enforcer.aclose()
+    assert client.is_closed is False  # injected client is owned by the caller
+    await client.aclose()
+
+
+# === build_policy_enforcer_from_env(): fail-closed tier/mode matrix ========= #
+
+
+@pytest.mark.parametrize('tier', ['production', 'prod', 'staging', 'stage', 'PRODUCTION'])
+def test_deployed_tier_without_opa_url_fails_closed(
+    tier: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv('POLICY_MODE', raising=False)
+    monkeypatch.delenv('OPA_URL', raising=False)
+    monkeypatch.setenv('ENVIRONMENT', tier)
+
+    with pytest.raises(PolicyConfigError):
+        build_policy_enforcer_from_env()
+
+
+def test_environment_unset_defaults_to_deployed_safe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ENVIRONMENT absent entirely must behave like ENVIRONMENT=production,
+    matching the fail-closed default used by OIDC/audit (ISSUE 009/019)."""
+    monkeypatch.delenv('ENVIRONMENT', raising=False)
+    monkeypatch.delenv('POLICY_MODE', raising=False)
+    monkeypatch.delenv('OPA_URL', raising=False)
+
+    with pytest.raises(PolicyConfigError):
+        build_policy_enforcer_from_env()
+
+
+@pytest.mark.parametrize('tier', ['production', 'prod', 'staging', 'stage'])
+def test_deployed_tier_with_opa_url_builds_opa_enforcer(
+    tier: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv('POLICY_MODE', raising=False)
+    monkeypatch.setenv('OPA_URL', 'http://opa.internal:8181')
+    monkeypatch.setenv('ENVIRONMENT', tier)
+
+    enforcer = build_policy_enforcer_from_env()
+    assert isinstance(enforcer, OpaHttpPolicyEnforcer)
+
+
+@pytest.mark.parametrize('tier', ['dev', 'development', 'test', 'local', 'ci'])
+def test_non_deployed_tier_defaults_to_local_enforcer(
+    tier: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv('POLICY_MODE', raising=False)
+    monkeypatch.delenv('OPA_URL', raising=False)
+    monkeypatch.setenv('ENVIRONMENT', tier)
+
+    enforcer = build_policy_enforcer_from_env()
+    assert isinstance(enforcer, LocalPolicyEnforcer)
+
+
+def test_policy_mode_local_forbidden_on_deployed_tier(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('POLICY_MODE', 'local')
+    monkeypatch.setenv('ENVIRONMENT', 'production')
+
+    with pytest.raises(PolicyConfigError):
+        build_policy_enforcer_from_env()
+
+
+def test_policy_mode_local_allowed_on_non_deployed_tier(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('POLICY_MODE', 'local')
+    monkeypatch.setenv('ENVIRONMENT', 'dev')
+
+    enforcer = build_policy_enforcer_from_env()
+    assert isinstance(enforcer, LocalPolicyEnforcer)
+
+
+def test_policy_mode_opa_requires_opa_url_regardless_of_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv('POLICY_MODE', 'opa')
+    monkeypatch.delenv('OPA_URL', raising=False)
+    monkeypatch.setenv('ENVIRONMENT', 'dev')
+
+    with pytest.raises(PolicyConfigError):
+        build_policy_enforcer_from_env()
+
+
+def test_policy_mode_opa_builds_enforcer_even_on_dev_tier(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('POLICY_MODE', 'opa')
+    monkeypatch.setenv('OPA_URL', 'http://opa.internal:8181')
+    monkeypatch.setenv('ENVIRONMENT', 'dev')
+
+    enforcer = build_policy_enforcer_from_env()
+    assert isinstance(enforcer, OpaHttpPolicyEnforcer)
+
+
+def test_unknown_policy_mode_aborts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('POLICY_MODE', 'anything-goes')
+
+    with pytest.raises(PolicyConfigError):
+        build_policy_enforcer_from_env()
+
+
+def test_invalid_opa_timeout_seconds_aborts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('POLICY_MODE', 'opa')
+    monkeypatch.setenv('OPA_URL', 'http://opa.internal:8181')
+    monkeypatch.setenv('OPA_TIMEOUT_SECONDS', 'not-a-number')
+
+    with pytest.raises(PolicyConfigError):
+        build_policy_enforcer_from_env()

--- a/services/api-gateway/tests/runtime/test_policy_startup.py
+++ b/services/api-gateway/tests/runtime/test_policy_startup.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/tests/runtime/test_policy_startup.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Verifies AstraDesk behavior for the associated component.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Startup-time policy enforcer selection tests (ISSUE 028).
+
+Verifies that ``gateway.main.lifespan`` calls
+``runtime.policy_enforcer.build_policy_enforcer_from_env`` fail-closed —
+before any external resource (DB/Redis) is touched — mirroring the existing
+OIDC (ISSUE 009) and audit (ISSUE 019) fail-closed startup checks in the same
+function. The full tier/mode decision matrix itself is covered by
+``test_policy_enforcer.py``; this file only exercises the gateway wiring.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from gateway import main as gateway_main
+from runtime.policy_enforcer import PolicyConfigError
+
+
+@pytest.mark.asyncio
+async def test_lifespan_fails_closed_before_database_when_policy_unconfigured_in_production(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Audit is configured so the failure below is unambiguously attributable
+    # to the policy check, not the audit check that runs immediately before it.
+    monkeypatch.setenv('AUDIT_LOG_PATH', str(tmp_path / 'audit.jsonl'))
+    monkeypatch.setenv('ENVIRONMENT', 'production')
+    monkeypatch.delenv('POLICY_MODE', raising=False)
+    monkeypatch.delenv('OPA_URL', raising=False)
+    monkeypatch.setattr(gateway_main, 'install_verifier', lambda app: None)
+
+    async def unexpected_pool_creation(*args: object, **kwargs: object) -> None:
+        pytest.fail('database initialization ran before the policy config check')
+
+    monkeypatch.setattr(gateway_main.asyncpg, 'create_pool', unexpected_pool_creation)
+
+    with pytest.raises(PolicyConfigError):
+        async with gateway_main.lifespan(gateway_main.app):
+            pytest.fail('lifespan yielded despite missing policy configuration')
+
+
+@pytest.mark.asyncio
+async def test_lifespan_fails_closed_when_policy_mode_local_forbidden_in_production(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv('AUDIT_LOG_PATH', str(tmp_path / 'audit.jsonl'))
+    monkeypatch.setenv('ENVIRONMENT', 'production')
+    monkeypatch.setenv('POLICY_MODE', 'local')
+    monkeypatch.setattr(gateway_main, 'install_verifier', lambda app: None)
+
+    async def unexpected_pool_creation(*args: object, **kwargs: object) -> None:
+        pytest.fail('database initialization ran before the policy config check')
+
+    monkeypatch.setattr(gateway_main.asyncpg, 'create_pool', unexpected_pool_creation)
+
+    with pytest.raises(PolicyConfigError):
+        async with gateway_main.lifespan(gateway_main.app):
+            pytest.fail('lifespan yielded despite POLICY_MODE=local on a deployed tier')
+
+
+# A full-lifespan "dev tier does not fail closed" sanity check is already
+# covered end-to-end by ``tests/test_api.py::test_healthz_ok``, which runs the
+# real ``lifespan`` with ``ENVIRONMENT=dev`` (no ``POLICY_MODE``/``OPA_URL``)
+# and succeeds; duplicating that here would mean re-mocking the entire startup
+# chain (DB pool, Redis, RAG, domain-pack loading) for no additional signal —
+# the same reasoning ``test_audit_startup.py`` already documents for ISSUE 019.


### PR DESCRIPTION
## Summary

Completes ISSUE #028 by adding fail-closed contextual policy enforcement at the non-bypassable side-effect tool execution choke point.

Policy enforcement now happens in:

`ToolRegistry.execute()`

The enforcement order is:

1. RBAC / approval enforcement
2. contextual policy enforcement
3. pre-execution durable audit
4. tool invocation

This guarantees that LLM-planned and keyword-fallback paths share the same authoritative policy gate.

## What changed

- Added `runtime/policy_enforcer.py`.
- Added fail-closed policy enforcement for:
  - `write` tools;
  - `execute` tools;
  - optionally policy-governed `read` tools.
- Wired policy enforcement into `ToolRegistry.execute()`.
- Added deployed-tier policy configuration resolution during API Gateway startup.
- Added tests for:
  - policy enforcer behavior;
  - `ToolRegistry.execute()` choke-point enforcement;
  - startup fail-closed behavior.
- Updated:
  - `.env.example`
  - `README.md`
  - `docs/roadmap/issues/ISSUES_028_opa_fail_closed.md`

Existing orchestrator / agent / per-tool OPA checks remain untouched and non-authoritative. The registry choke point is now authoritative for side-effect execution.

## Enforcement point

Policy enforcement is performed in `ToolRegistry.execute()` after RBAC succeeds and before tool invocation.

A policy denial or policy dependency failure prevents the tool function from running.

## Deployed-tier behavior

For deployed tiers:

- `production`
- `prod`
- `staging`
- `stage`
- unset `ENVIRONMENT` as deployed-safe default

side-effect policy enforcement is fail-closed.

`OPA_URL` must be explicitly configured. Missing `OPA_URL` raises `PolicyConfigError` during startup before DB/Redis/RAG initialization.

`POLICY_MODE=local` is refused on deployed tiers.

At decision time, OPA failure, timeout, non-2xx response, or ambiguous response denies `write` / `execute` before invocation.

## Local/dev/test/CI behavior

Non-deployed tiers may use deterministic local policy mode.

Local policy mode does not bypass:

- OIDC/JWKS authentication;
- RBAC;
- approval/change-record checks;
- durable audit.

It only replaces the external OPA dependency for deterministic development and test execution.

## Environment variables

- `POLICY_MODE`
- `OPA_URL`
- `OPA_POLICY_PATH`
- `OPA_TIMEOUT_SECONDS`

## Policy decision input

Policy input is represented by `PolicyRequest` and contains only bounded/safe fields:

- tool name
- declared side effect
- normalized roles
- principal id
- tenant id
- trace id
- request id
- approval id
- bounded redacted args preview

It does not structurally include:

- raw JWTs;
- Authorization headers;
- secrets;
- private keys;
- raw full claims maps;
- unbounded tool args;
- raw PII.

## Audit behavior

Policy denials for side-effect tools are durably audited through the existing ISSUE #019 audit path.

A policy denial occurs before tool invocation and emits a denied audit event. If the audit sink fails while writing this denied event for a side-effecting tool, execution fails closed.

## Verification

- `uv run ruff check core/src services/api-gateway/src services/api-gateway/tests mcp/src mcp/tests`
- `uv run ruff format --check core/src services/api-gateway/src services/api-gateway/tests mcp/src mcp/tests`
- `uv run mypy <changed files>`
  - only the known pre-existing `opentelemetry.trace` baseline remains
- `uv run pytest -q services/api-gateway/tests mcp/tests`
  - 423 passed
- `uv run pytest -q --cov-report=xml:coverage.xml`
  - 442 passed
- `uv run python scripts/license_headers.py --check`
  - 0 files to normalize

## Non-goals

- OIDC/JWKS #009 was not redesigned.
- RBAC #016 was not redesigned.
- NEW-04 redaction/egress was not redesigned.
- Durable audit #019 was not redesigned.
- Admin API contract was not changed.
- Admin API proxy gap was not patched.
- OPA bundle supply-chain/versioning was not implemented.
- Schema-hash negotiation was not implemented.
- AstraCatalog policy versioning was not implemented.
- Java ticket adapter internals were not changed.
- No real OPA server is required in CI.
