### PR TITLE
Protect Admin proxy and API with defense-in-depth auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,13 @@ VLLM_TIMEOUT_SEC=60
 # OIDC / JWT Ingress Verification (ISSUE 009)
 # core/src/astradesk_core/utils/oidc.py, wired at API Gateway startup via
 # gateway/auth_dependency.install_verifier() (services/api-gateway/src/gateway/main.py).
+#
+# The same variables independently configure the Admin API's own verifier
+# (services/admin_api/src/astradesk_admin/auth.py, NEW-SEC): the API Gateway's
+# /api/admin/v1/{path} proxy requires an authenticated 'admin' principal
+# before forwarding, and the Admin API independently re-verifies the same
+# bearer token rather than trusting the proxy or network placement
+# (defense-in-depth). Set these identically for both services in production.
 # -----------------------------------------------------------------------------
 # AUTH_MODE selects the verifier. Defaults to "production" (JWKS/RS256 —
 # the only verifier deployed tiers may use). "local-dev" is the sole
@@ -140,6 +147,11 @@ OIDC_JWKS_URL=https://your-issuer.example.com/.well-known/jwks.json
 OIDC_ALGORITHMS=RS256
 OIDC_LEEWAY_SECONDS=30
 OIDC_JWKS_CACHE_TTL=600
+# OIDC_ROLES_CLAIM: claim holding the caller's roles (dotted paths supported,
+# e.g. "realm_access.roles" for Keycloak). For /api/admin/v1/* (Gateway) and
+# every Admin API operation except /health and /docs|/redoc|/openapi.json
+# (NEW-SEC), this list must contain "admin" (case-insensitive) or the
+# request is rejected with 403.
 OIDC_ROLES_CLAIM=roles
 OIDC_SCOPE_CLAIM=scope
 OIDC_REQUIRED_SCOPES=
@@ -155,7 +167,16 @@ ASTRADESK_DEV_JWT_SECRET=change-me-local-dev-only
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8080/api/admin/v1
 NEXT_PUBLIC_SIMULATION_MODE=false
 
-# Optional server-side token used for authenticated API calls.
+# Server-side bearer tokens the Admin Portal attaches as
+# `Authorization: Bearer <token>` when calling the Gateway's /api/admin/v1
+# proxy (src/api/client.ts uses ASTRADESK_API_TOKEN; src/clients/adminApi.ts
+# uses ADMIN_API_TOKEN — two existing client wrappers, same target route).
+# Since NEW-SEC, both the Gateway proxy and the Admin API independently
+# require a verified Bearer JWT whose role claim includes 'admin' — set
+# these to a real OIDC-issued admin-scoped token (or a locally-minted
+# AUTH_MODE=local-dev token for dev). An arbitrary string is no longer
+# accepted: it is rejected with 401 (invalid token) or 403 (missing 'admin'
+# role) at both layers.
 ASTRADESK_API_TOKEN=
 ADMIN_API_TOKEN=
 

--- a/README.md
+++ b/README.md
@@ -1082,6 +1082,12 @@ symlink to the canonical spec so the UI never drifts.
 - **Audit**: Logged to Postgres + NATS publish. Every `write`/`execute` tool attempt (allowed, denied, or errored) is additionally recorded through a durable `AuditWriter` at the `ToolRegistry.execute` choke point, on both the LLM-planned and keyword-fallback paths. Deployed tiers (`production`/`prod`/`staging`/`stage`) fail closed at startup without `AUDIT_LOG_PATH`; local/dev/test may fall back to a non-durable in-process writer.
 - **Policy (OPA, fail-closed)**: A contextual policy gate, independent of RBAC, additionally guards every `write`/`execute` tool attempt (and any `read` tool opted in with `policy_governed=True`) at the same `ToolRegistry.execute` choke point (`runtime.policy_enforcer`, ISSUE 028). Deployed tiers require a real OPA server (`POLICY_MODE=opa` or the safe default) — missing/invalid `OPA_URL` aborts startup, and a denied or unreachable OPA decision at call time denies the tool before it runs. `POLICY_MODE=local` (deterministic allow-all) is refused on deployed tiers. Policy denials are durably audited through the same ISSUE 019 path. Schema-hash negotiation and OPA bundle versioning remain future work (Track B).
 - **Policies**: Allow-lists in tools, proxy retries.
+- **Admin API defense-in-depth (NEW-SEC)**: `/api/admin/v1/{path}` requires an
+  authenticated `admin` principal at the API Gateway proxy **before** forwarding, and
+  the Admin API (`services/admin_api`) independently re-verifies the same Bearer JWT
+  and independently requires `admin` — neither layer trusts the other's decision or
+  network placement alone. Part of the security baseline alongside the OIDC/RBAC/audit/
+  policy hardening above; see [docs/en/08_security_governance.md §8.13](docs/en/08_security_governance.md#813-admin-api-defense-in-depth-new-sec).
 
 ## Roadmap
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,6 +37,7 @@ Dokument opisuje publiczne endpointy API Gateway dla systemu **AstraDesk**.
 - [Endpointy](#endpointy)
   - [GET /healthz](#get-healthz)
   - [POST /v1/agents/run](#post-v1agentsrun)
+  - [/api/admin/v1/{path} (proxy Admin API)](#apiadminv1path-proxy-admin-api)
 
 - [Kody błędów](#kody-błędów)
 
@@ -151,6 +152,36 @@ Agent wykonuje plan (planner) -> wywołuje niezbędne narzędzia (RBAC) -> final
 Authorization: Bearer <JWT>
 Content-Type: application/json
 ```
+
+<br>
+
+### `/api/admin/v1/{path}` (proxy Admin API)
+
+Reverse proxy do niezależnej usługi Admin API (`services/admin_api`). Obsługuje
+`GET`/`POST`/`PUT`/`DELETE`/`PATCH`/`OPTIONS`. Wymaga uwierzytelnionego
+principala z rolą **`admin`**, sprawdzanej przez Gateway **zanim** żądanie
+zostanie przekazane dalej (NEW-SEC, obrona wielowarstwowa):
+
+- Brak/niepoprawny `Authorization` → `401 Unauthorized`; żądanie **nie**
+  dociera do Admin API.
+- Uwierzytelniony principal bez roli `admin` → `403 Forbidden`; żądanie
+  **nie** dociera do Admin API.
+- Uwierzytelniony `admin` → żądanie jest przekazywane. Nagłówki
+  `X-AstraDesk-*` dostarczone przez klienta (np. `X-AstraDesk-Principal`,
+  `X-AstraDesk-Tenant`, `X-AstraDesk-Roles`) są usuwane przed przekazaniem —
+  **nie są one mechanizmem uwierzytelniania**. Nagłówek `Authorization` jest
+  przekazywany bez zmian, ponieważ Admin API **niezależnie** weryfikuje ten
+  sam token JWT, zamiast ufać decyzji Gateway lub samemu położeniu sieciowemu.
+
+**Endpointy publiczne Admin API** (bez wymogu tokenu): `GET /health` (status
+komponentów — bez sekretów/danych wrażliwych) oraz automatycznie generowane
+`/docs`, `/redoc`, `/openapi.json`. Wszystkie pozostałe operacje (np.
+`/secrets`, `/users`, `/roles`, `/policies`, `/audit`) wymagają roli `admin`
+zweryfikowanej **niezależnie także przez samo Admin API** — nie tylko przez
+Gateway.
+
+Szczegóły i przykłady `curl`: `services/admin_api/README.md` oraz
+[8. Security & Governance §8.13](en/08_security_governance.md#813-admin-api-defense-in-depth-new-sec).
 
 <br>
 

--- a/docs/en/02_architecture_overview.md
+++ b/docs/en/02_architecture_overview.md
@@ -341,6 +341,21 @@ flowchart TB
 
 * **Data**: secrets in manager (KMS/ASM), PII filters at ingress, egress allow-lists.
 
+* **Admin API defense-in-depth (NEW-SEC)**: the Admin API service boundary is guarded
+  twice, independently — it is never trusted solely by network placement or Docker
+  Compose isolation.
+  * **Gateway guard**: `/api/admin/v1/{path}` requires an authenticated principal with
+    the `admin` role before proxying; it strips caller-supplied `X-AstraDesk-*`
+    headers, which are never a valid authentication mechanism.
+  * **Admin API guard**: `services/admin_api` independently re-verifies the same
+    Bearer JWT and independently requires `admin`, regardless of the Gateway's
+    decision. Only `/health` and the auto-generated `/docs`/`/redoc`/`/openapi.json`
+    stay public.
+  * **Contract**: `openapi/astradesk-admin.v1.yaml` declares the `BearerAuth` security
+    scheme on protected operations. See
+    [8. Security & Governance §8.13](08_security_governance.md#813-admin-api-defense-in-depth-new-sec)
+    for the full model.
+
 <br>
 
 ---

--- a/docs/en/08_security_governance.md
+++ b/docs/en/08_security_governance.md
@@ -368,7 +368,62 @@ flowchart LR
 
 ---
 
-## 8.13 Cross-References
+## 8.13 Admin API Defense-in-Depth (NEW-SEC)
+
+The Admin API (`services/admin_api`) and its API Gateway proxy route
+(`/api/admin/v1/{path}`) are each independently guarded. Neither layer trusts
+network placement, Docker Compose isolation, or the other layer's decision as
+a substitute for its own check.
+
+**Layer 1 — API Gateway proxy.** `/api/admin/v1/{path:path}`
+(`services/api-gateway/src/gateway/main.py`) requires an authenticated
+principal (OIDC Bearer JWT, ISSUE 009) with the normalized `admin` role before
+forwarding anything upstream:
+
+- Missing or malformed `Authorization` → `401`, upstream is never called.
+- Authenticated principal without `admin` → `403`, upstream is never called.
+- Authenticated `admin` → the request is proxied. Caller-supplied
+  `X-AstraDesk-*` headers (`X-AstraDesk-Principal`, `X-AstraDesk-Tenant`,
+  `X-AstraDesk-Roles`, and any other `X-AstraDesk-*` header) are stripped
+  before forwarding — **these headers are never a valid authentication
+  mechanism**, only the verified `Authorization` bearer token is. That header
+  is forwarded unchanged, and only because Layer 2 independently re-verifies
+  it (see below) rather than trusting the Gateway's decision.
+
+**Layer 2 — Admin API.** `services/admin_api/src/astradesk_admin/auth.py`
+independently verifies the same Bearer JWT (via the shared
+`astradesk_core.utils.oidc` verifier, ISSUE 009's contract, not a redesign)
+and independently requires the normalized `admin` role, regardless of what
+the Gateway already decided:
+
+- Missing or invalid Bearer JWT → `401`.
+- Authenticated principal without `admin` → `403`.
+- `X-AstraDesk-*` headers are never read as identity by the Admin API; only a
+  verified Bearer JWT establishes a principal.
+
+**Public exceptions.** `GET /health` (liveness/dashboard status — no secrets,
+credentials, or per-user data) and FastAPI's auto-generated `/docs`, `/redoc`,
+`/openapi.json` (API shape only, no live data) remain unauthenticated. Every
+other Admin API operation requires `admin`.
+
+**Contract.** `openapi/astradesk-admin.v1.yaml` declares a `BearerAuth`
+(`http`/`bearer`/`JWT`) security scheme and applies it to every protected
+operation, so the requirement is visible in the OpenAPI contract, not only in
+code.
+
+**Not yet implemented (future hardening).** Service-to-service mTLS and
+Istio `AuthorizationPolicy` between the Gateway and the Admin API remain the
+network-layer requirement described elsewhere in this document (§8.6); this
+defense-in-depth work adds the application-layer guard on top of that and
+does not replace it. Signed internal service-identity tokens (as an
+alternative to the currently-stripped `X-AstraDesk-*` headers) are not
+implemented and are not required for the current invariant set.
+
+<br>
+
+---
+
+## 8.14 Cross-References
 
 - Next: [9. MCP Gateway & Domain Packs](09_mcp_gateway_domain_packs.md)
 

--- a/docs/roadmap/engineering_task.md
+++ b/docs/roadmap/engineering_task.md
@@ -117,6 +117,7 @@ Rationale for order: you cannot authorize (016) before you can authenticate (009
 | `ISSUES_028_opa_fail_closed.md` | rescope #28 | RESCOPE | Security | yes |
 | `ISSUES_NEW-01_supply_chain.md` | NEW-1 | NEW | Security | yes |
 | `ISSUES_NEW-02_reproducible_build.md` | NEW-2 | NEW | Simplicity | yes |
+| `ISSUES_NEW-SEC_admin_proxy_auth.md` | NEW-SEC | NEW | Security | yes |
 
 Each issue file is self-contained and follows one contract template (problem → analog disease → invariants → interface → failure modes → acceptance → evidence → out-of-scope).
 

--- a/docs/roadmap/issues/ISSUES_NEW-SEC_admin_proxy_auth.md
+++ b/docs/roadmap/issues/ISSUES_NEW-SEC_admin_proxy_auth.md
@@ -1,0 +1,207 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+Project: AstraDesk
+File: docs/roadmap/issues/ISSUES_NEW-SEC_admin_proxy_auth.md
+Website: https://www.astradesk.dev
+Repository: https://github.com/SSobol77/astradesk
+
+Description: Documents AstraDesk architecture, operation, or component behavior.
+
+Copyright (c) 2026 Siergej Sobolewski
+This file is part of AstraDesk.
+
+AstraDesk is licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for the full license text.
+-->
+
+# ISSUES_NEW-SEC — Admin API proxy defense-in-depth authentication/authorization (NEW)
+
+- **Track / Milestone**: A / `v0.3.1`
+- **Type**: NEW (deferred out of ISSUE 009 / ISSUE 028 as a dedicated security issue)
+- **Workhorse principle**: Security (good-sense)
+- **GA-gating**: yes — an unauthenticated path to `/secrets`, `/users`, `/policies`, etc. is a critical gap
+- **Audit anchors**: ISSUE 009 OIDC/JWKS audit; `services/api-gateway/src/gateway/main.py` (`/api/admin/v1/{path:path}`); `services/admin_api/src/astradesk_admin/main.py`
+- **Depends on**: ISSUE 009 (OIDC verifier/`Principal` contract reused, not redesigned)
+- **Independent of**: RBAC choke point (016), durable audit (019), policy enforcement (028), NEW-04 redaction/egress — none of these were redesigned
+
+## Origin
+
+During the ISSUE 009 OIDC/JWKS ingress audit, the agent found that
+`/api/admin/v1/{path}` in the API Gateway proxied to `services/admin_api`
+**without a gateway auth check**, while the Admin API itself did not
+independently guard its sensitive endpoints either. This was explicitly
+deferred out of #009/#028 and tracked as this dedicated issue.
+
+## Problem (current evidence, pre-fix)
+
+`services/api-gateway/src/gateway/main.py::proxy_to_admin_service` forwarded
+every request under `/api/admin/v1/{path}` to the Admin API with no
+`Depends(...)` auth gate at all. `services/admin_api/src/astradesk_admin/main.py`
+had no auth dependency of its own — every route (`/secrets`, `/users`,
+`/roles`, `/policies`, `/audit`, …) was reachable by any caller who could
+reach the Admin API's port, relying entirely on network placement/Compose
+isolation for protection.
+
+## Industry analog & childhood disease
+
+A common failure mode in agent/admin-panel architectures: the "internal"
+admin backend is left unauthenticated because it's assumed to be reachable
+only through a trusted proxy or private network. The disease is **trusting
+network topology as an authentication mechanism** — once that topology
+assumption breaks (a misconfigured route, a compromised pod, a debug port left
+open), there is no second gate. We immunize with defense-in-depth: two
+independent authentication/authorization checks, neither of which trusts the
+other's decision or the network path between them.
+
+## Architecture decision
+
+Option C — defense-in-depth. Both layers independently authenticate and
+authorize; neither relies solely on network placement, Compose isolation,
+ingress, internal headers, or the other layer's decision.
+
+## Target contract (invariants)
+
+- **INV-ADMIN-AUTH-1/5/6**: `/api/admin/v1/{path}` at the API Gateway requires
+  an authenticated principal with role `admin`; missing/invalid
+  `Authorization` → `401`, authenticated non-admin → `403`, both before any
+  upstream connection.
+- **INV-ADMIN-AUTH-2**: The Gateway's authorization check is the `admin` role,
+  reusing the existing ISSUE 016 `normalize_roles` case-fold convention.
+- **INV-ADMIN-AUTH-3/4/7/8**: The Admin API independently requires the same —
+  a verified Bearer JWT and the `admin` role — regardless of the Gateway's
+  decision.
+- **INV-ADMIN-AUTH-9/11**: The Gateway strips caller-supplied `X-AstraDesk-*`
+  identity headers before proxying; they are never a valid authentication
+  mechanism at either layer.
+- **INV-ADMIN-AUTH-10**: The Gateway forwards `Authorization` unchanged to the
+  Admin API only because the Admin API independently re-verifies the same
+  Bearer JWT.
+- **INV-ADMIN-AUTH-12**: No raw JWT, `Authorization` header, secret, or full
+  raw claim set is logged or echoed in an error response at either layer.
+- **INV-ADMIN-AUTH-13**: `GET /health` (Admin API) and `GET /healthz` (Gateway)
+  remain public — liveness/dashboard status only, no sensitive state.
+- **INV-ADMIN-AUTH-14**: Tests require no real external IdP, network,
+  Kubernetes, or cloud dependency.
+- **INV-FAIL-CLOSED**: Missing/invalid OIDC configuration aborts Admin API
+  startup (`AuthConfigError`), mirroring the Gateway's ISSUE 009 contract.
+
+## Interface / design
+
+- **Gateway**: `services/api-gateway/src/gateway/auth_dependency.py` gains
+  `require_admin_role` (`Depends(require_authenticated)` + `admin` role
+  check). `gateway/main.py`'s `proxy_to_admin_service` depends on it, strips
+  `X-AstraDesk-*` headers via `_strip_spoofable_headers`, and forwards
+  `Authorization` unchanged. Incidentally fixed a pre-existing bug where the
+  proxy returned a base `Response` around an async-generator body
+  (`aiter_bytes()`), which Starlette cannot render — every successful proxy
+  call would 500 regardless of auth; changed to `StreamingResponse`.
+- **Admin API**: new `services/admin_api/src/astradesk_admin/auth.py`
+  independently verifies the Bearer JWT via the shared
+  `astradesk_core.utils.oidc.build_verifier_from_env()`/`Principal` contract,
+  with a locally-duplicated (not imported) role-normalization helper to
+  respect the API Gateway/Admin API service boundary. A new `lifespan`
+  installs the verifier at startup (fail-closed). All routes except
+  `GET /health` and FastAPI's auto `/docs`/`/redoc`/`/openapi.json` are
+  registered on `admin_router = APIRouter(dependencies=[Depends(require_admin)])`.
+- **OpenAPI**: `openapi/astradesk-admin.v1.yaml` already declared a
+  `BearerAuth` (`http`/`bearer`/`JWT`) security scheme and applied it to some
+  operations; this change added `security: [BearerAuth]` to the 19 operations
+  that lacked it (`/jobs*`, `/dlq`, `/users*`, `/roles`, `/policies*`,
+  `/audit`, `/settings/{group}*`), so every protected operation now declares
+  the requirement in the contract, not only in code. Contract version
+  unchanged at `1.2.0`.
+- **Dependency wiring**: `services/admin_api/pyproject.toml` now depends on
+  `astradesk-core` (previously only used indirectly); root `pyproject.toml`
+  now lists `astradesk-admin-api` as a dependency (it was a workspace member
+  but not consumed by anything, so `uv sync` never installed it) and adds
+  `services/admin_api/tests` to `[tool.pytest.ini_options] testpaths`.
+
+## Failure modes & required behavior
+
+| Failure | Required behavior |
+| :--- | :--- |
+| Missing `Authorization` at Gateway | `401`, upstream never called |
+| Malformed/invalid token at Gateway | `401`, upstream never called |
+| Authenticated non-admin at Gateway | `403`, upstream never called |
+| Authenticated `admin` at Gateway | Proxied; `X-AstraDesk-*` stripped, `Authorization` forwarded |
+| Missing/invalid token at Admin API | `401` |
+| Authenticated non-admin at Admin API | `403` |
+| Missing OIDC config on a deployed tier (Admin API startup) | `AuthConfigError`, process does not start |
+| `X-AstraDesk-*` headers present, no Bearer JWT | `401` — headers are not trusted as identity |
+
+## Acceptance criteria (Definition of Done)
+
+- [x] Gateway: `/api/admin/v1/{path}` requires authenticated `admin`; 401/403
+  enforced before any upstream call
+  (`services/api-gateway/tests/runtime/test_admin_proxy_auth.py`).
+- [x] Gateway: caller-supplied `X-AstraDesk-*` headers stripped before
+  proxying (`test_admin_proxy_auth.py::test_strips_caller_supplied_internal_identity_headers`).
+- [x] Gateway: `Authorization` forwarded unchanged only on allowed admin
+  requests, never on denied ones
+  (`test_admin_proxy_auth.py::test_forwards_authorization_unchanged_on_allowed_admin_request`,
+  `test_denied_requests_never_forward_authorization_to_upstream`).
+- [x] Gateway: no raw token leak in response body/headers
+  (`test_admin_proxy_auth.py::test_401_and_403_responses_never_echo_raw_token`).
+- [x] Admin API: every sensitive operation independently requires Bearer JWT +
+  `admin`; `/health` stays public
+  (`services/admin_api/tests/test_admin_auth.py`, including a blanket sweep
+  over every `admin_router` route).
+- [x] Admin API: `X-AstraDesk-*` headers never trusted as identity
+  (`test_admin_auth.py::test_does_not_trust_spoofed_identity_headers`).
+- [x] Admin API: fail-closed startup without OIDC config
+  (`test_admin_auth.py::test_install_verifier_is_fail_closed_without_oidc_config`).
+- [x] OpenAPI: `BearerAuth` security scheme applied to all protected
+  operations (verified by a script sweep of `paths:`; 74 operations, 0
+  missing after the change).
+- [x] Existing ISSUE 009 (OIDC), 016 (RBAC), 019 (audit), 028 (policy) suites
+  re-run and pass unchanged (152 tests) — none were redesigned.
+- [ ] Admin Portal OpenAPI generation/sync (`npm run openapi:gen`,
+  `npm run openapi:check`, `npm run lint`, `npm run test`). *(Not run — Node.js
+  was unavailable in the implementing environment. The spec change is
+  additive-only (`security:` blocks only); neither generator currently emits
+  per-operation security metadata into `types.gen.ts`/`spec-operations.gen.ts`,
+  so content drift is unlikely, but `npm run openapi:check`'s mtime-based
+  staleness check **will** fail until a maintainer with Node.js regenerates.
+  This remains an open, maintainer-side action item.)*
+- [ ] Service-to-service mTLS / Istio `AuthorizationPolicy` between Gateway and
+  Admin API. *(Not implemented here — tracked as future network-layer
+  hardening; see `docs/en/08_security_governance.md` §8.13. This issue
+  delivers the application-layer guard, not a replacement for it.)*
+- [ ] Signed internal service-identity tokens as an alternative to the
+  (now-stripped) `X-AstraDesk-*` headers. *(Not implemented; not required for
+  the current invariant set.)*
+
+## Verification evidence (artifact)
+
+```bash
+uv run ruff check core/src services/api-gateway/src services/api-gateway/tests services/admin_api mcp/src mcp/tests
+uv run ruff format --check core/src services/api-gateway/src services/api-gateway/tests services/admin_api mcp/src mcp/tests
+uv run pytest -q services/api-gateway/tests services/admin_api/tests mcp/tests   # 448 passed
+uv run pytest -q                                                                  # 467 passed (repo-wide)
+uv run python scripts/license_headers.py --check
+bash scripts/check-openapi-version.sh
+```
+
+All passed. `mypy` on the four changed/new auth files (`gateway/auth_dependency.py`,
+`gateway/main.py`, `astradesk_admin/auth.py`, `astradesk_admin/main.py`)
+reported zero new errors — only the pre-existing, documented
+`opentelemetry.trace` baseline noise in unrelated transitively-imported
+modules.
+
+## Admin Portal / Node.js toolchain caveat
+
+Node.js was not available in the implementing environment, so
+`npm ci`, `npm run openapi:gen`, `npm run openapi:check`, `npm run lint`, and
+`npm run test` under `services/admin-portal` were **not run**. No generated
+TypeScript client files were hand-edited or regenerated. This is recorded as
+an explicit open item, not claimed as done — see `docs/workflows/openapi-contract.md`
+for the exact commands a maintainer must run before merge.
+
+## Out of scope
+
+NEW-02 (reproducible containers), NEW-01 (vulnerability triage), Admin Portal
+rewrite, OIDC/JWKS redesign (009), RBAC redesign (016), NEW-04
+redaction/egress redesign, durable audit redesign (019), policy enforcement
+redesign (028), service-to-service mTLS/Istio `AuthorizationPolicy`, signed
+internal service-identity tokens, OPA-based policy evaluation for Admin API
+operations (beyond the existing Gateway-side OPA tool-policy gate).

--- a/docs/workflows/openapi-contract.md
+++ b/docs/workflows/openapi-contract.md
@@ -24,6 +24,9 @@ Run this procedure **every time** you:
 
 - add, rename, or remove endpoints in `openapi/astradesk-admin.v1.yaml`
 - adjust schemas or parameters that affect the admin portal client
+- change security requirements on Admin API operations (e.g. add/remove a `security:`
+  block or edit `components.securitySchemes`, as NEW-SEC did when adding the
+  `BearerAuth` requirement to previously-unprotected operations)
 - regenerate OpenAPI-driven TypeScript helpers
 
 This is the single source of truth for contract updates—link to it in pull requests whenever an API change ships.
@@ -67,7 +70,16 @@ Optional but recommended:
    ```
    The command fails if artifacts are stale or missing.
 
-4. **Run quality gates locally**
+4. **Verify the contract version/shape guard**
+   ```bash
+   bash scripts/check-openapi-version.sh
+   ```
+   Confirms `openapi.version` (`3.1.0`) and `info.version` (`1.2.0`) are unchanged, and
+   that `services/admin-portal/openapi/OpenAPI.yaml` (if present as a real file rather
+   than a symlink) matches the canonical spec. Run this whenever the spec changes,
+   including security-only changes that don't touch schemas.
+
+5. **Run quality gates locally**
    ```bash
    npm run lint
    npm run typecheck
@@ -78,7 +90,7 @@ Optional but recommended:
    docker run --rm -v "$PWD":/app -w /app node:22 npm run typecheck
    ```
 
-5. **Stage and commit related changes together**
+6. **Stage and commit related changes together**
    ```bash
    git add openapi/astradesk-admin.v1.yaml \
            services/admin-portal/src/api/types.gen.ts \
@@ -88,7 +100,7 @@ Optional but recommended:
    ```
    Include any other touched files (e.g., UI updates) in the same changeset to keep history cohesive.
 
-6. **Push and open a pull request**
+7. **Push and open a pull request**
    - Reference this workflow in the PR description.
    - Ensure branch protection requires the **API contract sync** job to pass on CI.
 

--- a/openapi/astradesk-admin.v1.yaml
+++ b/openapi/astradesk-admin.v1.yaml
@@ -2051,6 +2051,8 @@ paths:
     post:
       tags: [Jobs & Schedules]
       summary: Create a new scheduled job
+      security:
+        - BearerAuth: []
       requestBody:
         required: true
         content:
@@ -2072,6 +2074,8 @@ paths:
     get:
       tags: [Jobs & Schedules]
       summary: Get job details
+      security:
+        - BearerAuth: []
       parameters:
         - name: id
           in: path
@@ -2095,6 +2099,8 @@ paths:
     put:
       tags: [Jobs & Schedules]
       summary: Update a job
+      security:
+        - BearerAuth: []
       parameters:
         - name: id
           in: path
@@ -2118,6 +2124,8 @@ paths:
     delete:
       tags: [Jobs & Schedules]
       summary: Delete a job
+      security:
+        - BearerAuth: []
       parameters:
         - name: id
           in: path
@@ -2214,6 +2222,8 @@ paths:
     post:
       tags: [Jobs & Schedules]
       summary: Resume a paused job
+      security:
+        - BearerAuth: []
       parameters:
         - name: id
           in: path
@@ -2240,6 +2250,8 @@ paths:
       tags: [Jobs & Schedules]
       summary: List items from the Dead-Letter Queue
       description: Retrieves a paginated list of failed messages or events that could not be processed.
+      security:
+        - BearerAuth: []
       parameters:
         - $ref: '#/components/parameters/PaginationLimit'
         - $ref: '#/components/parameters/PaginationOffset'
@@ -2297,6 +2309,8 @@ paths:
     post:
       tags: [Users & Roles]
       summary: Create or invite a new user
+      security:
+        - BearerAuth: []
       requestBody:
         required: true
         content:
@@ -2327,6 +2341,8 @@ paths:
     get:
       tags: [Users & Roles]
       summary: Get user details
+      security:
+        - BearerAuth: []
       parameters:
         - name: id
           in: path
@@ -2345,6 +2361,8 @@ paths:
     delete:
       tags: [Users & Roles]
       summary: Delete a user
+      security:
+        - BearerAuth: []
       parameters:
         - name: id
           in: path
@@ -2396,6 +2414,8 @@ paths:
     put:
       tags: [Users & Roles]
       summary: Update a user's role
+      security:
+        - BearerAuth: []
       parameters:
         - name: id
           in: path
@@ -2427,6 +2447,8 @@ paths:
     get:
       tags: [Users & Roles]
       summary: List available roles
+      security:
+        - BearerAuth: []
       responses:
         '200':
           description: A list of available role names.
@@ -2474,6 +2496,8 @@ paths:
     post:
       tags: [Policies]
       summary: Create a new policy
+      security:
+        - BearerAuth: []
       requestBody:
         required: true
         content:
@@ -2495,6 +2519,8 @@ paths:
     get:
       tags: [Policies]
       summary: Get policy details
+      security:
+        - BearerAuth: []
       parameters:
         - name: id
           in: path
@@ -2511,6 +2537,8 @@ paths:
     put:
       tags: [Policies]
       summary: Update a policy
+      security:
+        - BearerAuth: []
       parameters:
         - name: id
           in: path
@@ -2545,6 +2573,8 @@ paths:
     delete:
       tags: [Policies]
       summary: Delete a policy
+      security:
+        - BearerAuth: []
       parameters:
         - name: id
           in: path
@@ -2568,6 +2598,8 @@ paths:
       tags: [Policies]
       summary: Simulate a policy against a given input
       description: Allows for dry-running a policy to see the outcome without enforcing it.
+      security:
+        - BearerAuth: []
       parameters:
         - name: id
           in: path
@@ -2624,6 +2656,8 @@ paths:
         
         Critical for compliance reporting, security investigations, and operational audits.
         All entries are cryptographically signed to ensure integrity.
+      security:
+        - BearerAuth: []
       parameters:
         - name: userId
           in: query
@@ -2781,6 +2815,8 @@ paths:
         
         Critical for platform configuration management and system customization.
         Supports dynamic system behavior modification without service restarts.
+      security:
+        - BearerAuth: []
       parameters:
         - name: group
           in: path
@@ -2804,6 +2840,8 @@ paths:
       tags: [Settings]
       summary: Update a specific setting within a group
       description: Updates the value of a single setting identified by its key within a group.
+      security:
+        - BearerAuth: []
       parameters:
         - name: group
           in: path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ license = { text = "GPL-2.0-only" }
 dependencies = [
     "astradesk-core",
     "astradesk-api-gateway",
+    "astradesk-admin-api",
     "astradesk-auditor",
     "astradesk-domain-ops",
     "astradesk-domain-finance",
@@ -136,11 +137,12 @@ exclude = '^(src/|services/api_gateway/|\.venv/|build/|dist/|.*/build/)'
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-addopts = "--cov=core/src --cov=services/api-gateway/src --cov=mcp.src --cov=domain_support --cov=domain_ops --cov=domain_finance --cov=domain_supply --cov-report=xml --cov-report=term-missing"
+addopts = "--cov=core/src --cov=services/api-gateway/src --cov=services/admin_api/src --cov=mcp.src --cov=domain_support --cov=domain_ops --cov=domain_finance --cov=domain_supply --cov-report=xml --cov-report=term-missing"
 pythonpath = ["services/api-gateway/src"]
 testpaths = [
   "tests",
   "services/api-gateway/tests",
+  "services/admin_api/tests",
   "mcp/tests",
   "packages/domain-support/tests",
   "packages/domain-ops/tests",

--- a/services/admin_api/README.md
+++ b/services/admin_api/README.md
@@ -42,15 +42,12 @@ uv run uvicorn astradesk_admin.main:app --host 0.0.0.0 --port 8001 --reload
 
 ### Smoke Test
 ```bash
-# Liveness
-curl -s http://127.0.0.1:8001/healthz
-
-# Detailed health (components)
-curl -s http://127.0.0.1:8001/health/status
+# Health/dashboard status (public, no token required — see Authentication below)
+curl -s http://127.0.0.1:8001/health
 ```
-Expected minimal JSON:
+Expected JSON (shape; actual component states vary):
 ```json
-{"status": "ok"}
+{"status": "healthy", "components": {"database": "healthy", "vector_store": "healthy", "cache": "degraded"}}
 ```
 
 ---
@@ -110,10 +107,118 @@ uv run -m pytest -q
 
 ## 🩺 Health Endpoints
 
-- `GET /healthz` — simple liveness for Kubernetes
-- `GET /health/status` — aggregated component health with states `OK | DEGRADED | ERROR`
+- `GET /health` — aggregated component health/dashboard status. Deliberately left public
+  (no bearer token required): it exposes only coarse component states
+  (`healthy | degraded | down`) and no secrets, credentials, or per-user data, so it can
+  double as an unauthenticated liveness probe.
 
 Implementation lives in `src/astradesk_admin/main.py` and returns structured `pydantic` models.
+
+---
+
+## 🔐 Authentication & Authorization (NEW-SEC)
+
+Every Admin API operation **except** `/health` and the auto-generated `/docs`, `/redoc`,
+`/openapi.json` documentation routes independently requires:
+
+1. A verified Bearer JWT. Missing/invalid tokens are rejected with `401`.
+2. The normalized `admin` role on the verified principal. Authenticated callers without
+   it are rejected with `403`.
+
+This is implemented in `src/astradesk_admin/auth.py` and is **independent** of the API
+Gateway's own `/api/admin/v1/{path}` proxy gate
+(`services/api-gateway/src/gateway/auth_dependency.py`): the Admin API does not trust the
+Gateway's decision, network placement/Compose isolation, or any forwarded
+`X-AstraDesk-*` header as a substitute for its own verification (defense-in-depth,
+NEW-SEC). `X-AstraDesk-*` headers are never read as identity by the Admin API — they
+are not, and must never become, an authentication mechanism.
+
+### Required environment variables
+
+The Admin API reuses the **same** OIDC variables as the API Gateway (see the root
+`.env.example`) — set them identically for both services in production:
+
+| Variable | Purpose |
+| --- | --- |
+| `AUTH_MODE` | `production` (default, JWKS/RS256) or `local-dev` (see below). |
+| `OIDC_ISSUER` | Required in `AUTH_MODE=production`. Expected token `iss`. |
+| `OIDC_AUDIENCE` | Required in `AUTH_MODE=production`. Expected token `aud`. |
+| `OIDC_JWKS_URL` | Required in `AUTH_MODE=production`. JWKS endpoint for signature verification. |
+| `OIDC_ALGORITHMS` | Optional, default `RS256`. |
+| `OIDC_ROLES_CLAIM` | Optional, default `roles`. Dotted paths supported (e.g. `realm_access.roles` for Keycloak). |
+| `ENVIRONMENT` | Deployment tier. `production`/`prod`/`staging`/`stage` are **deployed tiers**: missing OIDC config aborts startup (`AuthConfigError`) rather than serving unauthenticated. |
+| `ASTRADESK_DEV_JWT_SECRET` | `AUTH_MODE=local-dev` only — symmetric HS256 secret for locally-minted test tokens. |
+
+Startup is **fail-closed**: on a deployed tier, missing/invalid OIDC configuration
+raises `AuthConfigError` and the process does not start (mirrors the API Gateway's
+ISSUE 009 contract — this is a reuse, not a redesign).
+
+### How the JWT is verified
+
+`src/astradesk_admin/auth.py` calls the shared
+`astradesk_core.utils.oidc.build_verifier_from_env()` to build its **own** verifier
+instance at startup (see `lifespan` in `src/astradesk_admin/main.py`). In
+`AUTH_MODE=production` (the only mode allowed on a deployed tier) this verifies the
+token's signature via JWKS, plus `iss`, `aud`, `exp`, and `nbf` (if present). The
+principal's role list is read from the claim named by `OIDC_ROLES_CLAIM` (default
+`roles`); the request is authorized only if that list contains `admin`
+(case-insensitive).
+
+### Local-dev auth mode
+
+For local testing without a real IdP, set `AUTH_MODE=local-dev` and
+`ASTRADESK_DEV_JWT_SECRET` (see root `.env.example`). This uses a symmetric HS256
+verifier instead of JWKS/RS256. It is refused at startup on any deployed tier
+(`ENVIRONMENT` ∈ `production`/`prod`/`staging`/`stage`) — it exists only as an
+explicitly-named local convenience, never a production fallback.
+
+### Public endpoints
+
+Only these routes require no Bearer token:
+
+- `GET /health` — aggregated component health/dashboard status (`healthy | degraded |
+  down` per component). No secrets, credentials, or per-user data.
+- `GET /docs`, `GET /redoc`, `GET /openapi.json` — FastAPI's auto-generated API
+  documentation/schema. These expose only the API shape (paths, parameters, schemas),
+  never live data, so they are intentionally left public.
+
+Every other operation (`/secrets`, `/users`, `/roles`, `/policies`, `/audit`, `/agents`,
+`/flows`, `/datasets`, `/connectors`, `/runs`, `/jobs`, `/dlq`, `/settings`,
+`/domain-packs`, …) requires a verified Bearer JWT with the `admin` role.
+
+### Example: verifying the gate with curl
+
+```bash
+# Missing token -> 401
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8001/secrets
+# 401
+
+# Authenticated but non-admin token -> 403
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H 'Authorization: Bearer <non-admin-bearer-token>' \
+  http://127.0.0.1:8001/secrets
+# 403
+
+# Authenticated admin token -> 200
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H 'Authorization: Bearer <admin-bearer-token>' \
+  http://127.0.0.1:8001/secrets
+# 200
+```
+
+Replace `<non-admin-bearer-token>` / `<admin-bearer-token>` with real tokens issued by
+your OIDC provider (or minted locally under `AUTH_MODE=local-dev`). Never paste real
+tokens into logs, tickets, or documentation.
+
+### ⚠️ Operational warning
+
+This service-level guard is **not** a substitute for network-layer protection. Do not
+expose the Admin API directly on a public network. Production deployments must still
+place it behind mTLS and a NetworkPolicy/Istio `AuthorizationPolicy` restricting which
+callers can reach it at all (see
+[docs/en/08_security_governance.md §8.13](../../docs/en/08_security_governance.md#813-admin-api-defense-in-depth-new-sec));
+that network-layer hardening is tracked separately and is **not** implemented by this
+change.
 
 ---
 
@@ -157,15 +262,24 @@ docker run --rm -p 8001:8001 astradesk-admin-api:dev
 
 ## 🔗 OpenAPI / Contract
 
-- **Source of truth:** `services/admin-portal/OpenAPI.yaml` (**v1.2.0**)
-- Planned: TS client generation for Admin UI + contract tests.
+- **Source of truth:** `openapi/astradesk-admin.v1.yaml` (**v1.2.0**); `services/admin-portal/OpenAPI.yaml`
+  is a symlink to the same file.
+- Protected operations declare a `BearerAuth` (`http`/`bearer`/`JWT`) security requirement
+  (NEW-SEC) — see `docs/workflows/openapi-contract.md` for the update procedure whenever
+  this contract changes.
+- Admin Portal TS client (`services/admin-portal/src/api/types.gen.ts`,
+  `spec-operations.gen.ts`) is generated from the spec via `npm run openapi:gen`; drift is
+  caught by `npm run openapi:check`.
 
 ---
 
 ## 🧭 Roadmap (short)
 
 - Wire real DB/cache/vector-store health checks
-- Add OPA/claims-based auth for admin endpoints
+- ~~Add OPA/claims-based auth for admin endpoints~~ — Bearer JWT + `admin` role
+  enforcement implemented (NEW-SEC, see Authentication & Authorization above); OPA-based
+  policy evaluation for Admin API operations (beyond the existing Gateway-side OPA
+  tool-policy gate) remains a possible future enhancement, not implemented here.
 - OpenTelemetry traces/metrics
 - CI with `uv` matrix (3.13), Docker, SBOM
 - Contract tests vs Admin API v1.2.0

--- a/services/admin_api/pyproject.toml
+++ b/services/admin_api/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
   "uvicorn[standard]>=0.30.0",
   "pydantic[email]>=2.6.0",
   "python-dotenv>=1.0.1",
+  # OIDC/JWT verification (Principal, build_verifier_from_env) reused from the
+  # shared core library rather than reimplemented (NEW-SEC; see ISSUE 009).
+  "astradesk-core",
   # add DB / observability, etc. when needed:
   # "asyncpg>=0.29.0",
   # "opentelemetry-sdk>=1.27.0",

--- a/services/admin_api/src/astradesk_admin/auth.py
+++ b/services/admin_api/src/astradesk_admin/auth.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/admin_api/src/astradesk_admin/auth.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Implements AstraDesk functionality for services/admin_api/src/astradesk_admin/auth.py.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Admin API ingress authentication and authorization (NEW-SEC).
+
+The Admin API is a separate service boundary from the API Gateway (see
+``docs/en/02_architecture_overview.md`` section 5). It must independently
+authenticate and authorize every sensitive operation rather than trusting the
+Gateway's decision, network placement/Compose isolation, or any caller-supplied
+``X-AstraDesk-*`` header as a substitute for a verified bearer token
+(INV-ADMIN-AUTH-3/4/9).
+
+This module mirrors ``services/api-gateway/src/gateway/auth_dependency.py``
+(ISSUE 009) and reuses the same ``astradesk_core.utils.oidc`` verifier /
+``Principal`` contract — it does not redesign OIDC/JWKS verification. Role
+normalization is deliberately re-implemented locally (a one-line case-fold)
+rather than imported from ``services/api-gateway/src/runtime/authz.py``: that
+module is API Gateway runtime internals, and the Admin API must not import
+across that service boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from astradesk_core.utils.oidc import (
+    AuthError,
+    Principal,
+    Verifier,
+    build_verifier_from_env,
+)
+from fastapi import Depends, FastAPI, Request
+from fastapi.exceptions import HTTPException
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
+
+__all__ = [
+    "get_principal",
+    "install_verifier",
+    "require_admin",
+    "require_authenticated",
+]
+
+_BEARER_PREFIX = "bearer "
+_ADMIN_ROLE = "admin"
+
+
+def install_verifier(app: FastAPI) -> None:
+    """Build and attach the OIDC verifier during Admin API startup.
+
+    Call from the lifespan/startup handler. Raises ``AuthConfigError`` if
+    required OIDC configuration is missing, which aborts process start
+    (fail-closed, INV-FAIL-CLOSED) rather than silently serving an
+    unauthenticated Admin API. This verifier instance is independent of the API
+    Gateway's own verifier; each service verifies the bearer JWT for itself.
+    """
+    app.state.token_verifier = build_verifier_from_env()
+
+
+def _extract_bearer(request: Request) -> str:
+    header = request.headers.get("authorization", "")
+    if not header or not header.lower().startswith(_BEARER_PREFIX):
+        raise AuthError("missing_token", "missing or malformed Authorization header")
+    return header[len(_BEARER_PREFIX) :].strip()
+
+
+def _normalize_roles(roles: Iterable[str]) -> frozenset[str]:
+    """Case-fold a principal's roles for comparison."""
+    return frozenset(r.casefold() for r in roles if r)
+
+
+async def require_authenticated(request: Request) -> Principal:
+    """Admin API ingress auth gate (INV-ADMIN-AUTH-3/7).
+
+    Independently verifies the Bearer JWT presented to the Admin API — it does
+    not trust the API Gateway's decision or any forwarded ``X-AstraDesk-*``
+    header (INV-ADMIN-AUTH-9). On failure: 401 with a stable, non-leaking
+    error code; the detail body never echoes token contents
+    (INV-ADMIN-AUTH-12).
+    """
+    verifier: Verifier = request.app.state.token_verifier
+    try:
+        token = _extract_bearer(request)
+        principal = verifier.verify(token)
+    except AuthError as exc:
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail={"error": exc.code},
+            headers={"WWW-Authenticate": f'Bearer error="{exc.code}"'},
+        ) from exc
+    request.state.principal = principal
+    return principal
+
+
+async def require_admin(principal: Principal = Depends(require_authenticated)) -> Principal:
+    """Admin API authorization gate: require the normalized ``admin`` role.
+
+    Runs after ``require_authenticated``, so a missing/invalid token is already
+    rejected with 401. An authenticated principal without the ``admin`` role is
+    rejected with 403 (INV-ADMIN-AUTH-4/8) — independent of any authorization
+    decision already made by the API Gateway.
+    """
+    if _ADMIN_ROLE not in _normalize_roles(principal.roles):
+        raise HTTPException(
+            status_code=HTTP_403_FORBIDDEN,
+            detail={"error": "admin_role_required"},
+        )
+    return principal
+
+
+def get_principal(request: Request) -> Principal:
+    """Retrieve the Principal attached by require_authenticated (downstream use)."""
+    principal = getattr(request.state, "principal", None)
+    if principal is None:
+        raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail={"error": "unauthenticated"})
+    return principal

--- a/services/admin_api/src/astradesk_admin/main.py
+++ b/services/admin_api/src/astradesk_admin/main.py
@@ -17,15 +17,19 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
 from uuid import uuid4
 from pathlib import Path
 import tomllib
 
-from fastapi import FastAPI, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Response, status
 from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import BaseModel, EmailStr, Field
+
+from astradesk_admin.auth import install_verifier, require_admin
 
 
 def iso_now() -> str:
@@ -536,6 +540,19 @@ store = DataStore()
 
 # --- FastAPI application ---
 
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    """Fail-closed startup: install the OIDC verifier before serving traffic.
+
+    Mirrors ``gateway.auth_dependency.install_verifier`` (ISSUE 009): missing or
+    invalid OIDC configuration aborts process start rather than silently
+    serving an unauthenticated Admin API (INV-ADMIN-AUTH-3, INV-FAIL-CLOSED).
+    """
+    install_verifier(app)
+    yield
+
+
 app = FastAPI(
     title="AstraDesk Admin API",
     description="API for AstraDesk Admin v1.2 - operational and governance panel for agents, data, policies, and audits.",
@@ -546,7 +563,16 @@ app = FastAPI(
     openapi_url="/openapi.json",
     docs_url="/docs",
     redoc_url="/redoc",
+    lifespan=lifespan,
 )
+
+# Every operation registered on this router independently requires an
+# authenticated principal with the normalized 'admin' role
+# (INV-ADMIN-AUTH-3/4/8, NEW-SEC) — regardless of any decision already made by
+# the API Gateway proxy. Only /health (liveness/dashboard status, no sensitive
+# state) and the auto-generated docs/OpenAPI routes remain public; see
+# services/admin_api/README.md for the documented exception.
+admin_router = APIRouter(dependencies=[Depends(require_admin)])
 
 
 # --- Dashboard endpoints ---
@@ -557,12 +583,12 @@ async def get_health() -> HealthStatus:
     return store.health
 
 
-@app.get("/usage/llm", response_model=UsageMetrics, tags=["Dashboard"])
+@admin_router.get("/usage/llm", response_model=UsageMetrics, tags=["Dashboard"])
 async def get_usage() -> UsageMetrics:
     return store.usage
 
 
-@app.get("/errors/recent", response_model=List[RecentError], tags=["Dashboard"])
+@admin_router.get("/errors/recent", response_model=List[RecentError], tags=["Dashboard"])
 async def get_recent_errors(limit: int = 25, offset: int = 0) -> List[RecentError]:
     return store.recent_errors[offset : offset + limit]
 
@@ -570,13 +596,15 @@ async def get_recent_errors(limit: int = 25, offset: int = 0) -> List[RecentErro
 # --- Agent endpoints ---
 
 
-@app.get("/agents", response_model=List[Agent], tags=["Agents"])
+@admin_router.get("/agents", response_model=List[Agent], tags=["Agents"])
 async def list_agents(limit: int = 25, offset: int = 0) -> List[Agent]:
     agents = list(store.agents.values())
     return agents[offset : offset + limit]
 
 
-@app.post("/agents", response_model=Agent, status_code=status.HTTP_201_CREATED, tags=["Agents"])
+@admin_router.post(
+    "/agents", response_model=Agent, status_code=status.HTTP_201_CREATED, tags=["Agents"]
+)
 async def create_agent(payload: AgentConfigRequest) -> Agent:
     agent_id = str(uuid4())
     agent = Agent(
@@ -602,12 +630,12 @@ def _get_agent_or_404(agent_id: str) -> Agent:
     return agent
 
 
-@app.get("/agents/{agent_id}", response_model=Agent, tags=["Agents"])
+@admin_router.get("/agents/{agent_id}", response_model=Agent, tags=["Agents"])
 async def get_agent(agent_id: str) -> Agent:
     return _get_agent_or_404(agent_id)
 
 
-@app.put("/agents/{agent_id}", response_model=Agent, tags=["Agents"])
+@admin_router.put("/agents/{agent_id}", response_model=Agent, tags=["Agents"])
 async def update_agent(agent_id: str, payload: AgentConfigRequest) -> Agent:
     agent = _get_agent_or_404(agent_id)
     updated = agent.model_copy(
@@ -619,7 +647,7 @@ async def update_agent(agent_id: str, payload: AgentConfigRequest) -> Agent:
     return updated
 
 
-@app.delete("/agents/{agent_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Agents"])
+@admin_router.delete("/agents/{agent_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Agents"])
 async def delete_agent(agent_id: str) -> Response:
     if agent_id not in store.agents:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
@@ -629,7 +657,7 @@ async def delete_agent(agent_id: str) -> Response:
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@app.post("/agents/{agent_id}:test", tags=["Agents"])
+@admin_router.post("/agents/{agent_id}:test", tags=["Agents"])
 async def test_agent(agent_id: str, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     _get_agent_or_404(agent_id)
     return {
@@ -639,7 +667,7 @@ async def test_agent(agent_id: str, payload: Optional[Dict[str, Any]] = None) ->
     }
 
 
-@app.post("/agents/{agent_id}:clone", response_model=Agent, tags=["Agents"])
+@admin_router.post("/agents/{agent_id}:clone", response_model=Agent, tags=["Agents"])
 async def clone_agent(agent_id: str) -> Agent:
     agent = _get_agent_or_404(agent_id)
     clone_id = str(uuid4())
@@ -652,7 +680,7 @@ async def clone_agent(agent_id: str) -> Agent:
     return clone
 
 
-@app.post("/agents/{agent_id}:promote", response_model=Agent, tags=["Agents"])
+@admin_router.post("/agents/{agent_id}:promote", response_model=Agent, tags=["Agents"])
 async def promote_agent(agent_id: str) -> Agent:
     agent = _get_agent_or_404(agent_id)
     promoted = agent.model_copy(update={"env": "prod", "status": "active"})
@@ -660,7 +688,7 @@ async def promote_agent(agent_id: str) -> Agent:
     return promoted
 
 
-@app.get("/agents/{agent_id}/metrics", response_model=AgentMetrics, tags=["Agents"])
+@admin_router.get("/agents/{agent_id}/metrics", response_model=AgentMetrics, tags=["Agents"])
 async def get_agent_metrics(agent_id: str, timeWindow: Optional[str] = None) -> AgentMetrics:  # noqa: N803
     _get_agent_or_404(agent_id)
     metrics = store.agent_metrics.get(agent_id)
@@ -669,7 +697,7 @@ async def get_agent_metrics(agent_id: str, timeWindow: Optional[str] = None) -> 
     return metrics
 
 
-@app.get("/agents/{agent_id}/io", response_model=List[AgentIoMessage], tags=["Agents"])
+@admin_router.get("/agents/{agent_id}/io", response_model=List[AgentIoMessage], tags=["Agents"])
 async def get_agent_io(agent_id: str, limit: int = 25, offset: int = 0) -> List[AgentIoMessage]:
     _get_agent_or_404(agent_id)
     messages = store.agent_io.get(agent_id, [])
@@ -679,7 +707,7 @@ async def get_agent_io(agent_id: str, limit: int = 25, offset: int = 0) -> List[
 # --- Intent graph ---
 
 
-@app.get("/intents/graph", response_model=IntentGraph, tags=["Intent Graph"])
+@admin_router.get("/intents/graph", response_model=IntentGraph, tags=["Intent Graph"])
 async def get_intent_graph() -> IntentGraph:
     return store.intent_graph
 
@@ -694,7 +722,7 @@ def _get_flow_or_404(flow_id: str) -> Flow:
     return flow
 
 
-@app.get("/flows", response_model=FlowListResponse, tags=["Flows"])
+@admin_router.get("/flows", response_model=FlowListResponse, tags=["Flows"])
 async def list_flows(
     limit: int = 25,
     offset: int = 0,
@@ -711,7 +739,9 @@ async def list_flows(
     return FlowListResponse(items=sliced, total=total, limit=limit, offset=offset)
 
 
-@app.post("/flows", response_model=Flow, status_code=status.HTTP_201_CREATED, tags=["Flows"])
+@admin_router.post(
+    "/flows", response_model=Flow, status_code=status.HTTP_201_CREATED, tags=["Flows"]
+)
 async def create_flow(payload: FlowCreateRequest) -> Flow:
     flow_id = str(uuid4())
     config_yaml = json.dumps(payload.graph, indent=2)
@@ -730,12 +760,12 @@ async def create_flow(payload: FlowCreateRequest) -> Flow:
     return flow
 
 
-@app.get("/flows/{flow_id}", response_model=Flow, tags=["Flows"])
+@admin_router.get("/flows/{flow_id}", response_model=Flow, tags=["Flows"])
 async def get_flow(flow_id: str) -> Flow:
     return _get_flow_or_404(flow_id)
 
 
-@app.put("/flows/{flow_id}", response_model=Flow, tags=["Flows"])
+@admin_router.put("/flows/{flow_id}", response_model=Flow, tags=["Flows"])
 async def update_flow(flow_id: str, payload: FlowUpdateRequest) -> Flow:
     flow = _get_flow_or_404(flow_id)
     updated = flow.model_copy(
@@ -750,7 +780,7 @@ async def update_flow(flow_id: str, payload: FlowUpdateRequest) -> Flow:
     return updated
 
 
-@app.delete("/flows/{flow_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Flows"])
+@admin_router.delete("/flows/{flow_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Flows"])
 async def delete_flow(flow_id: str) -> Response:
     if flow_id not in store.flows:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Flow not found")
@@ -759,13 +789,13 @@ async def delete_flow(flow_id: str) -> Response:
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@app.post("/flows/{flow_id}:validate", response_model=FlowValidationResult, tags=["Flows"])
+@admin_router.post("/flows/{flow_id}:validate", response_model=FlowValidationResult, tags=["Flows"])
 async def validate_flow(flow_id: str) -> FlowValidationResult:
     _get_flow_or_404(flow_id)
     return FlowValidationResult(valid=True, errors=[])
 
 
-@app.post("/flows/{flow_id}:dryrun", response_model=FlowDryRunResult, tags=["Flows"])
+@admin_router.post("/flows/{flow_id}:dryrun", response_model=FlowDryRunResult, tags=["Flows"])
 async def dry_run_flow(flow_id: str) -> FlowDryRunResult:
     _get_flow_or_404(flow_id)
     steps = [
@@ -775,7 +805,7 @@ async def dry_run_flow(flow_id: str) -> FlowDryRunResult:
     return FlowDryRunResult(steps=steps)
 
 
-@app.post("/flows/{flow_id}:test", response_model=FlowTestResult, tags=["Flows"])
+@admin_router.post("/flows/{flow_id}:test", response_model=FlowTestResult, tags=["Flows"])
 async def test_flow(flow_id: str, payload: Optional[Dict[str, Any]] = None) -> FlowTestResult:
     _get_flow_or_404(flow_id)
     return FlowTestResult(
@@ -785,14 +815,14 @@ async def test_flow(flow_id: str, payload: Optional[Dict[str, Any]] = None) -> F
     )
 
 
-@app.get("/flows/{flow_id}/log", response_model=List[FlowLogEntry], tags=["Flows"])
+@admin_router.get("/flows/{flow_id}/log", response_model=List[FlowLogEntry], tags=["Flows"])
 async def get_flow_log(flow_id: str, limit: int = 25, offset: int = 0) -> List[FlowLogEntry]:
     _get_flow_or_404(flow_id)
     logs = store.flow_logs.get(flow_id, [])
     return logs[offset : offset + limit]
 
 
-@app.post("/flows/generate", tags=["Flows"])
+@admin_router.post("/flows/generate", tags=["Flows"])
 async def generate_flow(payload: FlowGenerationRequest) -> PlainTextResponse:
     generated = {
         "flow": {
@@ -819,13 +849,13 @@ def _get_dataset_or_404(dataset_id: str) -> Dataset:
     return dataset
 
 
-@app.get("/datasets", response_model=List[Dataset], tags=["Datasets"])
+@admin_router.get("/datasets", response_model=List[Dataset], tags=["Datasets"])
 async def list_datasets(limit: int = 25, offset: int = 0) -> List[Dataset]:
     datasets = list(store.datasets.values())
     return datasets[offset : offset + limit]
 
 
-@app.post(
+@admin_router.post(
     "/datasets", response_model=Dataset, status_code=status.HTTP_201_CREATED, tags=["Datasets"]
 )
 async def create_dataset(payload: DatasetCreateRequest) -> Dataset:
@@ -839,12 +869,14 @@ async def create_dataset(payload: DatasetCreateRequest) -> Dataset:
     return dataset
 
 
-@app.get("/datasets/{dataset_id}", response_model=Dataset, tags=["Datasets"])
+@admin_router.get("/datasets/{dataset_id}", response_model=Dataset, tags=["Datasets"])
 async def get_dataset(dataset_id: str) -> Dataset:
     return _get_dataset_or_404(dataset_id)
 
 
-@app.delete("/datasets/{dataset_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Datasets"])
+@admin_router.delete(
+    "/datasets/{dataset_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Datasets"]
+)
 async def delete_dataset(dataset_id: str) -> Response:
     if dataset_id not in store.datasets:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found")
@@ -854,7 +886,7 @@ async def delete_dataset(dataset_id: str) -> Response:
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@app.get("/datasets/{dataset_id}/schema", response_model=DatasetSchema, tags=["Datasets"])
+@admin_router.get("/datasets/{dataset_id}/schema", response_model=DatasetSchema, tags=["Datasets"])
 async def get_dataset_schema(dataset_id: str) -> DatasetSchema:
     _get_dataset_or_404(dataset_id)
     schema = store.dataset_schemas.get(dataset_id)
@@ -863,7 +895,7 @@ async def get_dataset_schema(dataset_id: str) -> DatasetSchema:
     return schema
 
 
-@app.get(
+@admin_router.get(
     "/datasets/{dataset_id}/embeddings", response_model=List[EmbeddingMetadata], tags=["Datasets"]
 )
 async def get_dataset_embeddings(
@@ -874,7 +906,9 @@ async def get_dataset_embeddings(
     return embeddings[offset : offset + limit]
 
 
-@app.post("/datasets/{dataset_id}:reindex", status_code=status.HTTP_202_ACCEPTED, tags=["Datasets"])
+@admin_router.post(
+    "/datasets/{dataset_id}:reindex", status_code=status.HTTP_202_ACCEPTED, tags=["Datasets"]
+)
 async def reindex_dataset(dataset_id: str) -> Dict[str, str]:
     _get_dataset_or_404(dataset_id)
     return {"job_id": str(uuid4())}
@@ -890,13 +924,13 @@ def _get_connector_or_404(connector_id: str) -> Connector:
     return connector
 
 
-@app.get("/connectors", response_model=List[Connector], tags=["Tools/Connectors"])
+@admin_router.get("/connectors", response_model=List[Connector], tags=["Tools/Connectors"])
 async def list_connectors(limit: int = 25, offset: int = 0) -> List[Connector]:
     connectors = list(store.connectors.values())
     return connectors[offset : offset + limit]
 
 
-@app.post(
+@admin_router.post(
     "/connectors",
     response_model=Connector,
     status_code=status.HTTP_201_CREATED,
@@ -909,12 +943,12 @@ async def create_connector(payload: ConnectorConfigRequest) -> Connector:
     return connector
 
 
-@app.get("/connectors/{connector_id}", response_model=Connector, tags=["Tools/Connectors"])
+@admin_router.get("/connectors/{connector_id}", response_model=Connector, tags=["Tools/Connectors"])
 async def get_connector(connector_id: str) -> Connector:
     return _get_connector_or_404(connector_id)
 
 
-@app.put("/connectors/{connector_id}", response_model=Connector, tags=["Tools/Connectors"])
+@admin_router.put("/connectors/{connector_id}", response_model=Connector, tags=["Tools/Connectors"])
 async def update_connector(connector_id: str, payload: ConnectorConfigRequest) -> Connector:
     connector = _get_connector_or_404(connector_id)
     updated = connector.model_copy(
@@ -924,7 +958,7 @@ async def update_connector(connector_id: str, payload: ConnectorConfigRequest) -
     return updated
 
 
-@app.delete(
+@admin_router.delete(
     "/connectors/{connector_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Tools/Connectors"]
 )
 async def delete_connector(connector_id: str) -> Response:
@@ -934,13 +968,13 @@ async def delete_connector(connector_id: str) -> Response:
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@app.post("/connectors/{connector_id}:test", tags=["Tools/Connectors"])
+@admin_router.post("/connectors/{connector_id}:test", tags=["Tools/Connectors"])
 async def test_connector(connector_id: str) -> Dict[str, Any]:
     _get_connector_or_404(connector_id)
     return {"success": True, "message": "Connector authentication succeeded."}
 
 
-@app.post("/connectors/{connector_id}:probe", tags=["Tools/Connectors"])
+@admin_router.post("/connectors/{connector_id}:probe", tags=["Tools/Connectors"])
 async def probe_connector(connector_id: str) -> Dict[str, Any]:
     _get_connector_or_404(connector_id)
     return {"success": True, "latency_ms": 128.0}
@@ -956,13 +990,13 @@ def _get_secret_or_404(secret_id: str) -> SecretMetadata:
     return secret
 
 
-@app.get("/secrets", response_model=List[SecretMetadata], tags=["Keys & Secrets"])
+@admin_router.get("/secrets", response_model=List[SecretMetadata], tags=["Keys & Secrets"])
 async def list_secrets(limit: int = 25, offset: int = 0) -> List[SecretMetadata]:
     secrets = list(store.secrets.values())
     return secrets[offset : offset + limit]
 
 
-@app.post(
+@admin_router.post(
     "/secrets",
     response_model=SecretMetadata,
     status_code=status.HTTP_201_CREATED,
@@ -981,7 +1015,7 @@ async def create_secret(payload: SecretCreateRequest) -> SecretMetadata:
     return metadata
 
 
-@app.post(
+@admin_router.post(
     "/secrets/{secret_id}:rotate", response_model=SecretCreateRequest, tags=["Keys & Secrets"]
 )
 async def rotate_secret(secret_id: str) -> SecretCreateRequest:
@@ -991,7 +1025,7 @@ async def rotate_secret(secret_id: str) -> SecretCreateRequest:
     return SecretCreateRequest(name=secret.name, value=f"rotated-{uuid4()}", type=secret.type)
 
 
-@app.delete(
+@admin_router.delete(
     "/secrets/{secret_id}:disable", status_code=status.HTTP_204_NO_CONTENT, tags=["Keys & Secrets"]
 )
 async def disable_secret(secret_id: str) -> Response:
@@ -1011,7 +1045,7 @@ def _get_run_or_404(run_id: str) -> Run:
     return run
 
 
-@app.get("/runs", response_model=List[Run], tags=["Runs & Logs"])
+@admin_router.get("/runs", response_model=List[Run], tags=["Runs & Logs"])
 async def list_runs(
     agentId: Optional[str] = None,  # noqa: N803
     status: Optional[str] = None,
@@ -1028,12 +1062,12 @@ async def list_runs(
     return runs[offset : offset + limit]
 
 
-@app.get("/runs/{run_id}", response_model=Run, tags=["Runs & Logs"])
+@admin_router.get("/runs/{run_id}", response_model=Run, tags=["Runs & Logs"])
 async def get_run(run_id: str) -> Run:
     return _get_run_or_404(run_id)
 
 
-@app.get("/runs/stream", tags=["Runs & Logs"])
+@admin_router.get("/runs/stream", tags=["Runs & Logs"])
 async def stream_runs(
     agentId: Optional[str] = None,  # noqa: N803
     status: Optional[str] = None,
@@ -1053,7 +1087,7 @@ async def stream_runs(
     return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 
-@app.get("/logs/export", tags=["Runs & Logs"])
+@admin_router.get("/logs/export", tags=["Runs & Logs"])
 async def export_logs(
     format: Literal["json", "ndjson", "csv"], agentId: Optional[str] = None
 ) -> PlainTextResponse:  # noqa: N803
@@ -1084,13 +1118,13 @@ def _get_job_or_404(job_id: str) -> Job:
     return job
 
 
-@app.get("/jobs", response_model=List[Job], tags=["Jobs & Schedules"])
+@admin_router.get("/jobs", response_model=List[Job], tags=["Jobs & Schedules"])
 async def list_jobs(limit: int = 25, offset: int = 0) -> List[Job]:
     jobs = list(store.jobs.values())
     return jobs[offset : offset + limit]
 
 
-@app.post(
+@admin_router.post(
     "/jobs", response_model=Job, status_code=status.HTTP_201_CREATED, tags=["Jobs & Schedules"]
 )
 async def create_job(payload: JobCreateRequest) -> Job:
@@ -1106,12 +1140,12 @@ async def create_job(payload: JobCreateRequest) -> Job:
     return job
 
 
-@app.get("/jobs/{job_id}", response_model=Job, tags=["Jobs & Schedules"])
+@admin_router.get("/jobs/{job_id}", response_model=Job, tags=["Jobs & Schedules"])
 async def get_job(job_id: str) -> Job:
     return _get_job_or_404(job_id)
 
 
-@app.put("/jobs/{job_id}", response_model=Job, tags=["Jobs & Schedules"])
+@admin_router.put("/jobs/{job_id}", response_model=Job, tags=["Jobs & Schedules"])
 async def update_job(job_id: str, payload: JobCreateRequest) -> Job:
     _get_job_or_404(job_id)
     job = Job(
@@ -1125,7 +1159,9 @@ async def update_job(job_id: str, payload: JobCreateRequest) -> Job:
     return job
 
 
-@app.delete("/jobs/{job_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Jobs & Schedules"])
+@admin_router.delete(
+    "/jobs/{job_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Jobs & Schedules"]
+)
 async def delete_job(job_id: str) -> Response:
     if job_id not in store.jobs:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
@@ -1133,14 +1169,16 @@ async def delete_job(job_id: str) -> Response:
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@app.post("/jobs/{job_id}:trigger", status_code=status.HTTP_202_ACCEPTED, tags=["Jobs & Schedules"])
+@admin_router.post(
+    "/jobs/{job_id}:trigger", status_code=status.HTTP_202_ACCEPTED, tags=["Jobs & Schedules"]
+)
 async def trigger_job(job_id: str) -> Dict[str, str]:
     _get_job_or_404(job_id)
     run_id = str(uuid4())
     return {"run_id": run_id}
 
 
-@app.post("/jobs/{job_id}:pause", response_model=Job, tags=["Jobs & Schedules"])
+@admin_router.post("/jobs/{job_id}:pause", response_model=Job, tags=["Jobs & Schedules"])
 async def pause_job(job_id: str) -> Job:
     job = _get_job_or_404(job_id)
     paused = job.model_copy(update={"status": "paused"})
@@ -1148,7 +1186,7 @@ async def pause_job(job_id: str) -> Job:
     return paused
 
 
-@app.post("/jobs/{job_id}:resume", response_model=Job, tags=["Jobs & Schedules"])
+@admin_router.post("/jobs/{job_id}:resume", response_model=Job, tags=["Jobs & Schedules"])
 async def resume_job(job_id: str) -> Job:
     job = _get_job_or_404(job_id)
     resumed = job.model_copy(update={"status": "active"})
@@ -1156,7 +1194,7 @@ async def resume_job(job_id: str) -> Job:
     return resumed
 
 
-@app.get("/dlq", response_model=List[DLQItem], tags=["Jobs & Schedules"])
+@admin_router.get("/dlq", response_model=List[DLQItem], tags=["Jobs & Schedules"])
 async def list_dlq(limit: int = 25, offset: int = 0) -> List[DLQItem]:
     items = list(store.dlq_items.values())
     return items[offset : offset + limit]
@@ -1172,13 +1210,13 @@ def _get_user_or_404(user_id: str) -> User:
     return user
 
 
-@app.get("/users", response_model=List[User], tags=["Users & Roles"])
+@admin_router.get("/users", response_model=List[User], tags=["Users & Roles"])
 async def list_users(limit: int = 25, offset: int = 0) -> List[User]:
     users = list(store.users.values())
     return users[offset : offset + limit]
 
 
-@app.post(
+@admin_router.post(
     "/users", response_model=User, status_code=status.HTTP_201_CREATED, tags=["Users & Roles"]
 )
 async def create_user(payload: UserCreateRequest) -> User:
@@ -1190,12 +1228,14 @@ async def create_user(payload: UserCreateRequest) -> User:
     return user
 
 
-@app.get("/users/{user_id}", response_model=User, tags=["Users & Roles"])
+@admin_router.get("/users/{user_id}", response_model=User, tags=["Users & Roles"])
 async def get_user(user_id: str) -> User:
     return _get_user_or_404(user_id)
 
 
-@app.delete("/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Users & Roles"])
+@admin_router.delete(
+    "/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Users & Roles"]
+)
 async def delete_user(user_id: str) -> Response:
     if user_id not in store.users:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
@@ -1203,13 +1243,13 @@ async def delete_user(user_id: str) -> Response:
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@app.post("/users/{user_id}:reset-mfa", tags=["Users & Roles"])
+@admin_router.post("/users/{user_id}:reset-mfa", tags=["Users & Roles"])
 async def reset_mfa(user_id: str) -> Dict[str, bool]:
     _get_user_or_404(user_id)
     return {"success": True}
 
 
-@app.put("/users/{user_id}/role", response_model=User, tags=["Users & Roles"])
+@admin_router.put("/users/{user_id}/role", response_model=User, tags=["Users & Roles"])
 async def update_user_role(user_id: str, payload: UserRoleUpdateRequest) -> User:
     user = _get_user_or_404(user_id)
     updated = user.model_copy(update={"role": payload.role})
@@ -1217,7 +1257,7 @@ async def update_user_role(user_id: str, payload: UserRoleUpdateRequest) -> User
     return updated
 
 
-@app.get("/roles", response_model=List[str], tags=["Users & Roles"])
+@admin_router.get("/roles", response_model=List[str], tags=["Users & Roles"])
 async def list_roles() -> List[str]:
     return ["admin", "operator", "viewer"]
 
@@ -1232,13 +1272,13 @@ def _get_policy_or_404(policy_id: str) -> Policy:
     return policy
 
 
-@app.get("/policies", response_model=List[Policy], tags=["Policies"])
+@admin_router.get("/policies", response_model=List[Policy], tags=["Policies"])
 async def list_policies(limit: int = 25, offset: int = 0) -> List[Policy]:
     policies = list(store.policies.values())
     return policies[offset : offset + limit]
 
 
-@app.post(
+@admin_router.post(
     "/policies", response_model=Policy, status_code=status.HTTP_201_CREATED, tags=["Policies"]
 )
 async def create_policy(payload: PolicyCreateRequest) -> Policy:
@@ -1248,12 +1288,12 @@ async def create_policy(payload: PolicyCreateRequest) -> Policy:
     return policy
 
 
-@app.get("/policies/{policy_id}", response_model=Policy, tags=["Policies"])
+@admin_router.get("/policies/{policy_id}", response_model=Policy, tags=["Policies"])
 async def get_policy(policy_id: str) -> Policy:
     return _get_policy_or_404(policy_id)
 
 
-@app.put("/policies/{policy_id}", response_model=Policy, tags=["Policies"])
+@admin_router.put("/policies/{policy_id}", response_model=Policy, tags=["Policies"])
 async def update_policy(policy_id: str, payload: PolicyCreateRequest) -> Policy:
     _get_policy_or_404(policy_id)
     policy = Policy(id=policy_id, name=payload.name, rego_text=payload.rego_text)
@@ -1261,7 +1301,9 @@ async def update_policy(policy_id: str, payload: PolicyCreateRequest) -> Policy:
     return policy
 
 
-@app.delete("/policies/{policy_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Policies"])
+@admin_router.delete(
+    "/policies/{policy_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Policies"]
+)
 async def delete_policy(policy_id: str) -> Response:
     if policy_id not in store.policies:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Policy not found")
@@ -1269,7 +1311,7 @@ async def delete_policy(policy_id: str) -> Response:
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@app.post(
+@admin_router.post(
     "/policies/{policy_id}:simulate", response_model=PolicySimulationResult, tags=["Policies"]
 )
 async def simulate_policy(
@@ -1291,7 +1333,7 @@ def _get_audit_or_404(audit_id: str) -> AuditEntry:
     return entry
 
 
-@app.get("/audit", response_model=List[AuditEntry], tags=["Audit Trail"])
+@admin_router.get("/audit", response_model=List[AuditEntry], tags=["Audit Trail"])
 async def list_audit(
     userId: Optional[str] = None,  # noqa: N803
     action: Optional[str] = None,
@@ -1311,12 +1353,12 @@ async def list_audit(
     return entries[offset : offset + limit]
 
 
-@app.get("/audit/{audit_id}", response_model=AuditEntry, tags=["Audit Trail"])
+@admin_router.get("/audit/{audit_id}", response_model=AuditEntry, tags=["Audit Trail"])
 async def get_audit_entry(audit_id: str) -> AuditEntry:
     return _get_audit_or_404(audit_id)
 
 
-@app.get("/audit/export", tags=["Audit Trail"])
+@admin_router.get("/audit/export", tags=["Audit Trail"])
 async def export_audit(
     format: Literal["json", "ndjson", "csv"],
     userId: Optional[str] = None,  # noqa: N803
@@ -1360,7 +1402,7 @@ def _get_settings_group_or_404(group: str) -> Dict[str, Setting]:
     return settings
 
 
-@app.get("/settings/{group}", response_model=List[Setting], tags=["Settings"])
+@admin_router.get("/settings/{group}", response_model=List[Setting], tags=["Settings"])
 async def list_settings(
     group: Literal["integrations", "localization", "platform"],
 ) -> List[Setting]:
@@ -1368,7 +1410,7 @@ async def list_settings(
     return list(settings.values())
 
 
-@app.put("/settings/{group}", response_model=Setting, tags=["Settings"])
+@admin_router.put("/settings/{group}", response_model=Setting, tags=["Settings"])
 async def update_setting(
     group: Literal["integrations", "localization", "platform"], payload: SettingUpdateRequest
 ) -> Setting:
@@ -1384,20 +1426,26 @@ async def update_setting(
 # --- Domain packs ---
 
 
-@app.get("/domain-packs", response_model=List[DomainPack], tags=["Domain Packs"])
+@admin_router.get("/domain-packs", response_model=List[DomainPack], tags=["Domain Packs"])
 async def list_domain_packs() -> List[DomainPack]:
     return store.domain_packs
 
 
-@app.post(
+@admin_router.post(
     "/domain-packs/{name}:install", status_code=status.HTTP_202_ACCEPTED, tags=["Domain Packs"]
 )
 async def install_domain_pack(name: str) -> Dict[str, str]:
     return {"job_id": str(uuid4()), "pack": name}
 
 
-@app.post(
+@admin_router.post(
     "/domain-packs/{name}:uninstall", status_code=status.HTTP_202_ACCEPTED, tags=["Domain Packs"]
 )
 async def uninstall_domain_pack(name: str) -> Dict[str, str]:
     return {"job_id": str(uuid4()), "pack": name}
+
+
+# Every route above (all except /health) is registered on admin_router and
+# therefore independently requires an authenticated 'admin' principal
+# (INV-ADMIN-AUTH-3/4/8, NEW-SEC).
+app.include_router(admin_router)

--- a/services/admin_api/tests/test_admin_auth.py
+++ b/services/admin_api/tests/test_admin_auth.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/admin_api/tests/test_admin_auth.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Verifies AstraDesk behavior for the associated component.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Admin API's own authentication/authorization gate (NEW-SEC).
+
+Covers INV-ADMIN-AUTH-3/4/7/8/9/12/13: every sensitive Admin API operation
+independently requires a verified Bearer JWT and the normalized 'admin' role,
+regardless of any decision already made by the API Gateway proxy. /health
+stays public. No caller-supplied X-AstraDesk-* header is trusted as identity.
+No raw token is ever echoed back.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+import pytest
+from astradesk_core.utils.oidc import AuthConfigError, AuthError, Principal
+from fastapi.testclient import TestClient
+
+from astradesk_admin.auth import install_verifier
+from astradesk_admin.main import admin_router, app
+
+_ADMIN_PRINCIPAL = Principal(subject="admin-1", roles=("admin",), scopes=(), claims={})
+_VIEWER_PRINCIPAL = Principal(subject="viewer-1", roles=("viewer",), scopes=(), claims={})
+_SECRET_TOKEN = "raw-secret-jwt-value-should-never-leak"
+
+_PATH_PARAM_RE = re.compile(r"\{[^/]+\}")
+
+
+class _RecordingVerifier:
+    """Deterministic stand-in for the real OIDC verifier on app.state."""
+
+    def __init__(self, principal: Principal | None = None, error: AuthError | None = None) -> None:
+        self._principal = principal
+        self._error = error
+        self.tokens: list[str] = []
+
+    def verify(self, token: str) -> Principal:
+        self.tokens.append(token)
+        if self._error is not None:
+            raise self._error
+        assert self._principal is not None
+        return self._principal
+
+
+@pytest.fixture
+def admin_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[tuple[TestClient, _RecordingVerifier]]:
+    verifier = _RecordingVerifier(principal=_ADMIN_PRINCIPAL)
+    monkeypatch.setattr(app.state, "token_verifier", verifier, raising=False)
+    client = TestClient(app)
+    yield client, verifier
+    client.close()
+
+
+def test_health_remains_public(
+    admin_client: tuple[TestClient, _RecordingVerifier],
+) -> None:
+    client, verifier = admin_client
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert verifier.tokens == []
+
+
+def test_sensitive_endpoint_rejects_missing_authorization(
+    admin_client: tuple[TestClient, _RecordingVerifier],
+) -> None:
+    client, verifier = admin_client
+
+    response = client.get("/secrets")
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["error"] == "missing_token"
+    assert verifier.tokens == []
+
+
+def test_sensitive_endpoint_rejects_invalid_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    verifier = _RecordingVerifier(error=AuthError("invalid_token", "bad signature"))
+    monkeypatch.setattr(app.state, "token_verifier", verifier, raising=False)
+    client = TestClient(app)
+
+    response = client.get("/secrets", headers={"Authorization": "Bearer bad.token"})
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["error"] == "invalid_token"
+    client.close()
+
+
+def test_sensitive_endpoint_rejects_authenticated_non_admin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verifier = _RecordingVerifier(principal=_VIEWER_PRINCIPAL)
+    monkeypatch.setattr(app.state, "token_verifier", verifier, raising=False)
+    client = TestClient(app)
+
+    response = client.get("/secrets", headers={"Authorization": "Bearer viewer.token"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["error"] == "admin_role_required"
+    client.close()
+
+
+def test_sensitive_endpoint_allows_authenticated_admin(
+    admin_client: tuple[TestClient, _RecordingVerifier],
+) -> None:
+    client, verifier = admin_client
+
+    response = client.get("/secrets", headers={"Authorization": "Bearer good.token"})
+
+    assert response.status_code == 200
+    assert verifier.tokens == ["good.token"]
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/users", "/roles", "/policies", "/audit", "/jobs", "/dlq", "/usage/llm"],
+)
+def test_representative_sensitive_endpoints_reject_unauthenticated(
+    admin_client: tuple[TestClient, _RecordingVerifier], path: str
+) -> None:
+    client, _verifier = admin_client
+
+    response = client.get(path)
+
+    assert response.status_code == 401
+
+
+def test_does_not_trust_spoofed_identity_headers(
+    admin_client: tuple[TestClient, _RecordingVerifier],
+) -> None:
+    client, verifier = admin_client
+
+    response = client.get(
+        "/secrets",
+        headers={
+            "X-AstraDesk-Principal": "spoofed-user",
+            "X-AstraDesk-Tenant": "spoofed-tenant",
+            "X-AstraDesk-Roles": "admin",
+        },
+    )
+
+    assert response.status_code == 401
+    assert verifier.tokens == []
+
+
+def test_401_and_403_responses_never_echo_raw_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    bad_verifier = _RecordingVerifier(
+        error=AuthError("invalid_token", f"rejected: {_SECRET_TOKEN}")
+    )
+    monkeypatch.setattr(app.state, "token_verifier", bad_verifier, raising=False)
+    client = TestClient(app)
+
+    response = client.get("/secrets", headers={"Authorization": f"Bearer {_SECRET_TOKEN}"})
+
+    assert response.status_code == 401
+    assert _SECRET_TOKEN not in response.text
+    assert _SECRET_TOKEN not in str(response.headers)
+    client.close()
+
+
+def test_all_admin_router_routes_reject_unauthenticated_requests(
+    admin_client: tuple[TestClient, _RecordingVerifier],
+) -> None:
+    """Blanket regression guard: every route registered on ``admin_router``
+    (i.e. every Admin API operation except /health and the auto-generated
+    docs/OpenAPI routes) must require authentication. This fails loudly if a
+    future endpoint is ever added directly on ``app`` instead of
+    ``admin_router``, bypassing the 'admin' gate (INV-ADMIN-AUTH-3/4)."""
+    client, _verifier = admin_client
+
+    assert len(admin_router.routes) > 0
+    checked = 0
+    for route in admin_router.routes:
+        path = _PATH_PARAM_RE.sub("placeholder", route.path)
+        methods = route.methods - {"HEAD", "OPTIONS"}
+        method = sorted(methods)[0]
+        response = client.request(method, path)
+        assert (
+            response.status_code == 401
+        ), f"{method} {path} did not require authentication (got {response.status_code})"
+        checked += 1
+
+    assert checked == len(admin_router.routes)
+
+
+def test_install_verifier_is_fail_closed_without_oidc_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mirrors gateway.auth_dependency's fail-closed startup contract
+    (ISSUE 009, INV-FAIL-CLOSED): missing OIDC configuration must abort
+    Admin API startup, not silently serve an unauthenticated API."""
+    monkeypatch.delenv("AUTH_MODE", raising=False)
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    monkeypatch.delenv("OIDC_AUDIENCE", raising=False)
+    monkeypatch.delenv("OIDC_JWKS_URL", raising=False)
+
+    with pytest.raises(AuthConfigError):
+        install_verifier(app)

--- a/services/admin_api/tests/test_admin_auth.py
+++ b/services/admin_api/tests/test_admin_auth.py
@@ -29,6 +29,7 @@ from collections.abc import Iterator
 
 import pytest
 from astradesk_core.utils.oidc import AuthConfigError, AuthError, Principal
+from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
 from astradesk_admin.auth import install_verifier
@@ -185,9 +186,10 @@ def test_all_admin_router_routes_reject_unauthenticated_requests(
     ``admin_router``, bypassing the 'admin' gate (INV-ADMIN-AUTH-3/4)."""
     client, _verifier = admin_client
 
-    assert len(admin_router.routes) > 0
+    api_routes = [route for route in admin_router.routes if isinstance(route, APIRoute)]
+    assert len(api_routes) > 0
     checked = 0
-    for route in admin_router.routes:
+    for route in api_routes:
         path = _PATH_PARAM_RE.sub("placeholder", route.path)
         methods = route.methods - {"HEAD", "OPTIONS"}
         method = sorted(methods)[0]
@@ -197,7 +199,7 @@ def test_all_admin_router_routes_reject_unauthenticated_requests(
         ), f"{method} {path} did not require authentication (got {response.status_code})"
         checked += 1
 
-    assert checked == len(admin_router.routes)
+    assert checked == len(api_routes)
 
 
 def test_install_verifier_is_fail_closed_without_oidc_config(

--- a/services/api-gateway/src/gateway/auth_dependency.py
+++ b/services/api-gateway/src/gateway/auth_dependency.py
@@ -21,13 +21,20 @@ from astradesk_core.utils.oidc import (
     Verifier,
     build_verifier_from_env,
 )
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.exceptions import HTTPException
-from starlette.status import HTTP_401_UNAUTHORIZED
+from runtime.authz import normalize_roles
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 
-__all__ = ['get_principal', 'install_verifier', 'require_authenticated']
+__all__ = [
+    'get_principal',
+    'install_verifier',
+    'require_admin_role',
+    'require_authenticated',
+]
 
 _BEARER_PREFIX = 'bearer '
+_ADMIN_ROLE = 'admin'
 
 
 def install_verifier(app: FastAPI) -> None:
@@ -64,6 +71,26 @@ async def require_authenticated(request: Request) -> Principal:
             headers={'WWW-Authenticate': f'Bearer error="{exc.code}"'},
         ) from exc
     request.state.principal = principal
+    return principal
+
+
+async def require_admin_role(
+    principal: Principal = Depends(require_authenticated),
+) -> Principal:
+    """Gateway authorization gate for the Admin API proxy (INV-ADMIN-AUTH-2/6).
+
+    Runs after ``require_authenticated``, so a missing/invalid token is already
+    rejected with 401 before this check. An authenticated principal without the
+    normalized ``admin`` role is rejected with 403 — before the request reaches
+    the Admin API upstream (NEW-SEC). Reuses the same case-fold role convention
+    as the RBAC choke point (ISSUE 016, :func:`runtime.authz.normalize_roles`)
+    rather than inventing a second one.
+    """
+    if _ADMIN_ROLE not in normalize_roles(principal.roles):
+        raise HTTPException(
+            status_code=HTTP_403_FORBIDDEN,
+            detail={'error': 'admin_role_required'},
+        )
     return principal
 
 

--- a/services/api-gateway/src/gateway/main.py
+++ b/services/api-gateway/src/gateway/main.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import logging
 import os
 import uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterable
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -44,6 +44,7 @@ from agents.ops import OpsAgent
 from agents.support import SupportAgent
 from astradesk_core.utils.oidc import Principal
 from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
+from fastapi.responses import StreamingResponse
 from model_gateway.llm_planner import LLMPlanner
 from model_gateway.router import provider_router
 from opa_client.opa import OpaClient
@@ -61,7 +62,11 @@ import asyncpg
 import redis.asyncio as redis
 
 # AstraDesk imports
-from gateway.auth_dependency import install_verifier, require_authenticated
+from gateway.auth_dependency import (
+    install_verifier,
+    require_admin_role,
+    require_authenticated,
+)
 from gateway.orchestrator import AgentNotFoundError, AgentOrchestrator, PolicyViolationError
 
 # --- Configuration ---
@@ -274,17 +279,57 @@ def healthz() -> dict[str, str]:
     return {'status': 'ok'}
 
 
+# Caller-supplied identity headers that must never be trusted from the inbound
+# request: the gateway is the only party permitted to assert them, and only
+# after its own OIDC + RBAC gate has run (INV-ADMIN-AUTH-9/11).
+_SPOOFABLE_HEADER_PREFIX = b'x-astradesk-'
+
+
+def _strip_spoofable_headers(
+    raw_headers: Iterable[tuple[bytes, bytes]],
+) -> list[tuple[bytes, bytes]]:
+    """Drop caller-supplied ``X-AstraDesk-*`` headers before proxying upstream.
+
+    These headers would otherwise let a caller self-assert principal/tenant/role
+    identity to the Admin API out-of-band of the verified bearer token
+    (INV-ADMIN-AUTH-9/11). The ``Authorization`` header is preserved unchanged:
+    it is forwarded only because the caller has already been authenticated and
+    authorized as ``admin`` by :func:`gateway.auth_dependency.require_admin_role`
+    above, and the Admin API independently re-verifies the same JWT
+    (INV-ADMIN-AUTH-10).
+    """
+    return [
+        (name, value)
+        for name, value in raw_headers
+        if not name.lower().startswith(_SPOOFABLE_HEADER_PREFIX)
+    ]
+
+
 @app.api_route(
     '/api/admin/v1/{path:path}',
     methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     tags=['Admin Proxy'],
     summary='Proxy for the Admin API service',
-    description='This endpoint acts as a reverse proxy, forwarding all requests to the separate Admin API microservice.',
+    description=(
+        'Reverse proxy to the Admin API microservice. Requires an authenticated '
+        "principal with the 'admin' role before any request reaches the Admin "
+        'API (NEW-SEC); the Admin API independently re-verifies the same '
+        'bearer token rather than trusting this proxy or network placement.'
+    ),
 )
-async def proxy_to_admin_service(request: Request) -> Response:
+async def proxy_to_admin_service(
+    request: Request,
+    principal: Principal = Depends(require_admin_role),
+) -> Response:
     """
     Reverse proxies all requests for /api/admin/v1 to the Admin API service.
-    It streams the request and response for efficiency.
+
+    Gated by ``require_admin_role`` (INV-ADMIN-AUTH-1/2/5/6): a missing or
+    invalid token is rejected with 401, and an authenticated non-admin caller
+    is rejected with 403 — both before any upstream connection is attempted.
+    Caller-supplied ``X-AstraDesk-*`` identity headers are stripped from the
+    forwarded request; the verified ``Authorization`` header is forwarded
+    unchanged (INV-ADMIN-AUTH-9/10/11).
     """
     client: httpx.AsyncClient | None = app_state.get('admin_api_client')
     if not client:
@@ -303,7 +348,7 @@ async def proxy_to_admin_service(request: Request) -> Response:
     proxied_req = client.build_request(
         method=request.method,
         url=url,
-        headers=request.headers.raw,
+        headers=_strip_spoofable_headers(request.headers.raw),
         content=request.stream(),
     )
 
@@ -316,8 +361,12 @@ async def proxy_to_admin_service(request: Request) -> Response:
             detail='Unable to connect to the Admin API service.',
         )
 
-    # Stream the response back to the client
-    return Response(
+    # Stream the response back to the client. StreamingResponse (not the base
+    # Response) is required here: Starlette's base Response only renders
+    # bytes/memoryview and cannot accept an async-generator body such as
+    # ``aiter_bytes()`` — using it would raise on every successful proxy call,
+    # independent of authentication.
+    return StreamingResponse(
         content=proxied_resp.aiter_bytes(),
         status_code=proxied_resp.status_code,
         headers=proxied_resp.headers,

--- a/services/api-gateway/tests/runtime/test_admin_proxy_auth.py
+++ b/services/api-gateway/tests/runtime/test_admin_proxy_auth.py
@@ -24,7 +24,7 @@ leak the raw token.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping, Sequence
 
 import httpx
 import pytest
@@ -58,7 +58,16 @@ class _RecordingAdminClient:
         self.sent_requests: list[httpx.Request] = []
 
     def build_request(
-        self, method: str, url: httpx.URL, headers: object = None, content: object = None
+        self,
+        method: str,
+        url: httpx.URL,
+        headers: httpx.Headers
+        | Mapping[str, str]
+        | Mapping[bytes, bytes]
+        | Sequence[tuple[str, str]]
+        | Sequence[tuple[bytes, bytes]]
+        | None = None,
+        content: object = None,
     ) -> httpx.Request:
         return httpx.Request(method, f'http://admin-api{url}', headers=headers)
 

--- a/services/api-gateway/tests/runtime/test_admin_proxy_auth.py
+++ b/services/api-gateway/tests/runtime/test_admin_proxy_auth.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Project: AstraDesk
+# File: services/api-gateway/tests/runtime/test_admin_proxy_auth.py
+# Website: https://www.astradesk.dev
+# Repository: https://github.com/SSobol77/astradesk
+#
+# Description: Verifies AstraDesk behavior for the associated component.
+#
+# Copyright (c) 2026 Siergej Sobolewski
+#
+# This file is part of AstraDesk.
+#
+# AstraDesk is licensed under the GNU General Public License version 2 only.
+# See the LICENSE file in the project root for the full license text.
+
+"""Gateway-side auth gate for the Admin API proxy (NEW-SEC).
+
+Covers INV-ADMIN-AUTH-1/2/5/6/9/10/11/12: the /api/admin/v1/{path} proxy must
+authenticate and authorize (role 'admin') before ever touching the upstream
+Admin API client, must strip caller-supplied X-AstraDesk-* identity headers,
+must forward Authorization unchanged only for allowed requests, and must never
+leak the raw token.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from astradesk_core.utils.oidc import AuthError, Principal
+from fastapi.testclient import TestClient
+from gateway import main as gateway_main
+
+_ADMIN_PRINCIPAL = Principal(subject='admin-1', roles=('admin',), scopes=(), claims={})
+_VIEWER_PRINCIPAL = Principal(subject='viewer-1', roles=('viewer',), scopes=(), claims={})
+_SECRET_TOKEN = 'raw-secret-jwt-value-should-never-leak'
+
+
+class _RecordingVerifier:
+    def __init__(self, principal: Principal | None = None, error: AuthError | None = None) -> None:
+        self._principal = principal
+        self._error = error
+        self.tokens: list[str] = []
+
+    def verify(self, token: str) -> Principal:
+        self.tokens.append(token)
+        if self._error is not None:
+            raise self._error
+        assert self._principal is not None
+        return self._principal
+
+
+class _RecordingAdminClient:
+    """Stand-in for the httpx.AsyncClient used to reach the Admin API."""
+
+    def __init__(self) -> None:
+        self.sent_requests: list[httpx.Request] = []
+
+    def build_request(
+        self, method: str, url: httpx.URL, headers: object = None, content: object = None
+    ) -> httpx.Request:
+        return httpx.Request(method, f'http://admin-api{url}', headers=headers)
+
+    async def send(self, request: httpx.Request, stream: bool = False) -> httpx.Response:
+        self.sent_requests.append(request)
+        return httpx.Response(200, json={'ok': True}, request=request)
+
+
+@pytest.fixture
+def admin_proxy_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[tuple[TestClient, _RecordingVerifier, _RecordingAdminClient]]:
+    verifier = _RecordingVerifier(principal=_ADMIN_PRINCIPAL)
+    admin_client = _RecordingAdminClient()
+    monkeypatch.setattr(gateway_main.app.state, 'token_verifier', verifier, raising=False)
+    monkeypatch.setitem(gateway_main.app_state, 'admin_api_client', admin_client)
+    client = TestClient(gateway_main.app)
+    yield client, verifier, admin_client
+    client.close()
+
+
+def test_missing_authorization_returns_401_before_upstream_call(
+    admin_proxy_client: tuple[TestClient, _RecordingVerifier, _RecordingAdminClient],
+) -> None:
+    client, verifier, admin_client = admin_proxy_client
+
+    response = client.get('/api/admin/v1/secrets')
+
+    assert response.status_code == 401
+    assert response.json()['detail']['error'] == 'missing_token'
+    assert verifier.tokens == []
+    assert admin_client.sent_requests == []
+
+
+def test_malformed_authorization_returns_401_before_upstream_call(
+    admin_proxy_client: tuple[TestClient, _RecordingVerifier, _RecordingAdminClient],
+) -> None:
+    client, verifier, admin_client = admin_proxy_client
+
+    response = client.get('/api/admin/v1/secrets', headers={'Authorization': 'Token abc'})
+
+    assert response.status_code == 401
+    assert response.json()['detail']['error'] == 'missing_token'
+    assert verifier.tokens == []
+    assert admin_client.sent_requests == []
+
+
+def test_invalid_token_returns_401_before_upstream_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verifier = _RecordingVerifier(error=AuthError('invalid_token', 'bad signature'))
+    admin_client = _RecordingAdminClient()
+    monkeypatch.setattr(gateway_main.app.state, 'token_verifier', verifier, raising=False)
+    monkeypatch.setitem(gateway_main.app_state, 'admin_api_client', admin_client)
+    client = TestClient(gateway_main.app)
+
+    response = client.get('/api/admin/v1/secrets', headers={'Authorization': 'Bearer bad.token'})
+
+    assert response.status_code == 401
+    assert response.json()['detail']['error'] == 'invalid_token'
+    assert admin_client.sent_requests == []
+    client.close()
+
+
+def test_authenticated_non_admin_returns_403_before_upstream_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verifier = _RecordingVerifier(principal=_VIEWER_PRINCIPAL)
+    admin_client = _RecordingAdminClient()
+    monkeypatch.setattr(gateway_main.app.state, 'token_verifier', verifier, raising=False)
+    monkeypatch.setitem(gateway_main.app_state, 'admin_api_client', admin_client)
+    client = TestClient(gateway_main.app)
+
+    response = client.get('/api/admin/v1/secrets', headers={'Authorization': 'Bearer viewer.token'})
+
+    assert response.status_code == 403
+    assert response.json()['detail']['error'] == 'admin_role_required'
+    assert admin_client.sent_requests == []
+    client.close()
+
+
+def test_authenticated_admin_reaches_upstream_and_is_proxied(
+    admin_proxy_client: tuple[TestClient, _RecordingVerifier, _RecordingAdminClient],
+) -> None:
+    client, verifier, admin_client = admin_proxy_client
+
+    response = client.get(
+        '/api/admin/v1/secrets', headers={'Authorization': f'Bearer {_SECRET_TOKEN}'}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {'ok': True}
+    assert verifier.tokens == [_SECRET_TOKEN]
+    assert len(admin_client.sent_requests) == 1
+
+
+def test_strips_caller_supplied_internal_identity_headers(
+    admin_proxy_client: tuple[TestClient, _RecordingVerifier, _RecordingAdminClient],
+) -> None:
+    client, _verifier, admin_client = admin_proxy_client
+
+    client.get(
+        '/api/admin/v1/secrets',
+        headers={
+            'Authorization': 'Bearer good.token',
+            'X-AstraDesk-Principal': 'spoofed-user',
+            'X-AstraDesk-Tenant': 'spoofed-tenant',
+            'X-AstraDesk-Roles': 'admin',
+            'X-AstraDesk-Whatever': 'also-spoofed',
+        },
+    )
+
+    assert len(admin_client.sent_requests) == 1
+    forwarded = admin_client.sent_requests[0].headers
+    assert 'x-astradesk-principal' not in forwarded
+    assert 'x-astradesk-tenant' not in forwarded
+    assert 'x-astradesk-roles' not in forwarded
+    assert 'x-astradesk-whatever' not in forwarded
+
+
+def test_forwards_authorization_unchanged_on_allowed_admin_request(
+    admin_proxy_client: tuple[TestClient, _RecordingVerifier, _RecordingAdminClient],
+) -> None:
+    client, _verifier, admin_client = admin_proxy_client
+
+    client.get('/api/admin/v1/secrets', headers={'Authorization': f'Bearer {_SECRET_TOKEN}'})
+
+    assert len(admin_client.sent_requests) == 1
+    forwarded = admin_client.sent_requests[0].headers
+    assert forwarded['authorization'] == f'Bearer {_SECRET_TOKEN}'
+
+
+def test_denied_requests_never_forward_authorization_to_upstream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-admin / unauthenticated callers never reach the point where
+    Authorization would be forwarded — the upstream is never invoked at all
+    (INV-ADMIN-AUTH-6)."""
+    verifier = _RecordingVerifier(principal=_VIEWER_PRINCIPAL)
+    admin_client = _RecordingAdminClient()
+    monkeypatch.setattr(gateway_main.app.state, 'token_verifier', verifier, raising=False)
+    monkeypatch.setitem(gateway_main.app_state, 'admin_api_client', admin_client)
+    client = TestClient(gateway_main.app)
+
+    client.get('/api/admin/v1/secrets', headers={'Authorization': f'Bearer {_SECRET_TOKEN}'})
+
+    assert admin_client.sent_requests == []
+    client.close()
+
+
+def test_401_and_403_responses_never_echo_raw_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bad_verifier = _RecordingVerifier(
+        error=AuthError('invalid_token', f'rejected: {_SECRET_TOKEN}')
+    )
+    admin_client = _RecordingAdminClient()
+    monkeypatch.setattr(gateway_main.app.state, 'token_verifier', bad_verifier, raising=False)
+    monkeypatch.setitem(gateway_main.app_state, 'admin_api_client', admin_client)
+    client = TestClient(gateway_main.app)
+
+    response = client.get(
+        '/api/admin/v1/secrets', headers={'Authorization': f'Bearer {_SECRET_TOKEN}'}
+    )
+
+    assert response.status_code == 401
+    assert _SECRET_TOKEN not in response.text
+    assert _SECRET_TOKEN not in str(response.headers)
+    client.close()

--- a/uv.lock
+++ b/uv.lock
@@ -206,6 +206,7 @@ name = "astradesk"
 version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "astradesk-admin-api" },
     { name = "astradesk-api-gateway" },
     { name = "astradesk-auditor" },
     { name = "astradesk-core" },
@@ -247,6 +248,7 @@ ingestion = [
 
 [package.metadata]
 requires-dist = [
+    { name = "astradesk-admin-api", editable = "services/admin_api" },
     { name = "astradesk-api-gateway", editable = "services/api-gateway" },
     { name = "astradesk-auditor", editable = "services/auditor" },
     { name = "astradesk-core", editable = "core" },
@@ -284,6 +286,7 @@ name = "astradesk-admin-api"
 version = "0.3.0"
 source = { editable = "services/admin_api" }
 dependencies = [
+    { name = "astradesk-core" },
     { name = "fastapi" },
     { name = "pydantic", extra = ["email"] },
     { name = "python-dotenv" },
@@ -300,6 +303,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "astradesk-core", editable = "core" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },


### PR DESCRIPTION
## Summary

Closes NEW-SEC: protects the Admin API boundary with defense-in-depth authentication and authorization.

This PR secures both layers:

1. API Gateway `/api/admin/v1/{path}` proxy now requires authenticated `admin`.
2. Admin API independently verifies Bearer JWT and requires `admin` on protected operations.

This fixes the security gap discovered during the ISSUE #009 OIDC/JWKS audit, where the gateway admin proxy and Admin API sensitive endpoints were effectively unguarded.

## What changed

### API Gateway

- Added `require_admin_role` dependency.
- Gated `/api/admin/v1/{path:path}` before any upstream Admin API request.
- Missing/malformed/invalid token returns `401`.
- Authenticated non-admin returns `403`.
- Caller-provided `X-AstraDesk-*` identity headers are stripped before proxying.
- `Authorization` is forwarded only after Gateway has authenticated and authorized the caller as `admin`.
- Fixed the successful proxy path to use `StreamingResponse`.

### Admin API

- Added `services/admin_api/src/astradesk_admin/auth.py`.
- Admin API now independently verifies Bearer JWT via the shared OIDC verifier.
- Admin API independently requires normalized role `admin`.
- All Admin API routes are protected except public liveness/docs surfaces.
- Sensitive surfaces such as secrets, users, roles, and policies now require Bearer JWT + `admin`.

### OpenAPI / Admin Portal

- Updated `openapi/astradesk-admin.v1.yaml`.
- Added `BearerAuth` security requirements to protected Admin API operations.
- Ran Admin Portal OpenAPI generation/check maintainer-side:
  - `npm ci`
  - `npm run openapi:gen`
  - `npm run openapi:check`
  - `npm run lint`
  - `npm test`
- Generated TypeScript client did not require committed changes.

### Documentation

Updated:

- `.env.example`
- `README.md`
- `docs/api.md`
- `docs/en/02_architecture_overview.md`
- `docs/en/08_security_governance.md`
- `docs/workflows/openapi-contract.md`
- `services/admin_api/README.md`
- `docs/roadmap/engineering_task.md`

Added:

- `docs/roadmap/issues/ISSUES_NEW-SEC_admin_proxy_auth.md`

## Required role

The required admin role is:

`admin`

Role comparison is normalized/case-folded.

## Public unauthenticated Admin API endpoints

Documented public endpoints:

- `GET /health`
- `GET /docs`
- `GET /redoc`
- `GET /openapi.json`

These expose liveness/API shape only, not secrets or mutable admin state.

## Protected behavior

At both Gateway and Admin API layers:

- Missing/invalid Authorization → `401`
- Authenticated non-admin → `403`
- Authenticated admin → allowed

`X-AstraDesk-*` headers are not trusted as authentication.

## Verification

Python/backend:

- `uv run ruff check core/src services/api-gateway/src services/api-gateway/tests services/admin_api mcp/src mcp/tests`
- `uv run ruff format --check core/src services/api-gateway/src services/api-gateway/tests services/admin_api mcp/src mcp/tests`
- `uv run pytest -q services/api-gateway/tests/runtime/test_admin_proxy_auth.py services/admin_api/tests/test_admin_auth.py`
  - 25 passed
- `uv run pytest -q services/api-gateway/tests services/admin_api/tests mcp/tests`
  - 448 passed
- `uv run python scripts/license_headers.py --check`
- `bash scripts/check-openapi-version.sh`
- `uv run mypy services/api-gateway/src/gateway/auth_dependency.py services/api-gateway/src/gateway/main.py services/admin_api/src/astradesk_admin/auth.py services/admin_api/src/astradesk_admin/main.py`
  - only the known pre-existing `opentelemetry.trace` baseline remains

Admin Portal / OpenAPI maintainer-side:

- `npm ci`
- `npm run openapi:gen`
- `npm run openapi:check`
- `npm run lint`
- `npm test`
  - 3 test files / 4 tests passed

Note: `npm ci` reported 13 npm vulnerabilities. No `npm audit fix` was run; this is deferred to NEW-01 supply-chain/vulnerability triage.

## Non-goals

- OIDC/JWKS #009 was not redesigned.
- RBAC #016 was not redesigned.
- NEW-04 redaction/egress was not redesigned.
- Durable audit #019 was not redesigned.
- Policy #028 was not redesigned.
- NEW-02 reproducible containers were not implemented.
- NEW-01 vulnerability triage was not implemented.
- Admin Portal was not rewritten.
- Admin API response schemas were not changed.
- No hardcoded secrets were added.
- No real external IdP dependency was added to CI.
