### PR TITLE
docs: synchronize v0.3.0 release state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,6 +1039,40 @@ testing, comment out `claims: dict[str, Any] = Depends(auth_guard),` in the `run
 - Run: `make test` (Python), `make test-java`, `make test-admin`.
 - Coverage: Unit (pytest, JUnit, Vitest), integration (API flow).
 
+### Integration test gate (issue #18)
+
+`tests/integration_tests.py` drives the full Gateway → Agent → Tool → RAG
+flow (in-process FastAPI `app` via `TestClient`, real local-dev JWTs) plus
+HTTP connectivity checks against the 4 domain-pack MCP servers. It is
+wired as an explicit, required, always-run job
+(`integration-tests` in `.github/workflows/ci.yml`) — not part of the
+default `pytest -q` unit gate.
+
+Required backing services (`docker-compose.dev.yml`):
+
+```bash
+docker compose -f docker-compose.dev.yml up -d --wait --wait-timeout 180 \
+  postgres redis nats mcp-support mcp-ops mcp-finance mcp-supply
+```
+
+Exact gate command:
+
+```bash
+DATABASE_URL=postgresql://astradesk:astradesk@localhost:5432/astradesk \
+REDIS_URL=redis://localhost:6379/0 \
+NATS_URL=nats://localhost:4222 \
+AUTH_MODE=local-dev \
+ASTRADESK_DEV_JWT_SECRET=integration-test-secret \
+ENVIRONMENT=ci \
+uv run pytest -q -m integration tests/integration_tests.py
+```
+
+Expected result: **`5 passed`** — no `xfail`, no `skip`, no optional/
+best-effort MCP server path (all 4 must become healthy or the CI step
+itself fails). See `audit/evidence/18_integration_ci_gate.md` for the
+root-cause history and `audit/evidence/v0.3.0_final_validation.md` for the
+latest reproduction.
+
 ### Coverage reports
 
 Each stack emits a machine-readable coverage report that CI uploads as an artifact:

--- a/audit/evidence/v0.3.0_final_validation.md
+++ b/audit/evidence/v0.3.0_final_validation.md
@@ -1,0 +1,229 @@
+<!--
+SPDX-License-Identifier: GPL-2.0-only
+Project: AstraDesk
+File: audit/evidence/v0.3.0_final_validation.md
+Website: https://www.astradesk.dev
+Repository: https://github.com/SSobol77/astradesk
+
+Description: Documents AstraDesk architecture, operation, or component behavior.
+
+Copyright (c) 2026 Siergej Sobolewski
+This file is part of AstraDesk.
+
+AstraDesk is licensed under the GNU General Public License version 2 only.
+See the LICENSE file in the project root for the full license text.
+-->
+
+# v0.3.0 — Final validation before `develop` → `main` release
+
+Status: **milestone `v0.3.0 — AWS-Ready Deployment` is fully closed** (#17
+Terraform modules, #18 integration tests, #19 NATS subscriber, #20 Java
+adapter OIDC, #21 Admin Portal OIDC — all closed). This file records the
+documentation sync (issue #65) and the final validation evidence gathered
+on `issue/65-v030-release-docs-sync` (based on `develop`) immediately
+before the `develop` → `main` merge and `v0.3.0` release tag.
+
+**This file does not close #43 and does not mark `v0.3.1` complete.**
+`v0.3.1 — Commercial Workhorse Hardening` has closed 7 of 8 issues (28,
+37, 38, 39, 40, 41, 42); **issue #43** (Helm/Terraform/Istio live
+deployability) **remains open**, blocked on live AWS/Kubernetes checks
+that require a provisioned cluster/account — see
+`audit/evidence/43_deployability_verification.md`. No live AWS/Kubernetes
+check was performed as part of this pass.
+
+## Milestone state (via `gh issue list`, 2026-07-06)
+
+| Milestone | Total | Closed | Open |
+| :--- | :--- | :--- | :--- |
+| `v0.3.0 - AWS-Ready Deployment` | 5 (#17–#21) | 5 | 0 |
+| `v0.3.1 - Commercial Workhorse Hardening` | 8 (#28, #37–#43) | 7 | 1 (#43) |
+
+## Documentation sync performed (issue #65)
+
+- `docs/roadmap/index.md`: added a dated status-update callout (v0.3.0
+  fully closed, v0.3.1 blocked only on #43); updated Phase 2 item 5 and
+  the "Commercial Workhorse v1" gate's integration-gate checklist bullet
+  from "issue #18 → RESCOPE" (pending) to "done" with a citation to
+  `audit/evidence/18_integration_ci_gate.md`; added an execution-status
+  note under §5 Tracker actions confirming the RESCOPE/KEEP actions for
+  #9/#16/#18/#19/#21/#28 have all been carried out. The rest of the
+  document (a 2026-06-28 planning snapshot) is preserved unchanged, per
+  its own "nothing closed is reopened; history is preserved" policy.
+- `docs/roadmap/engineering_task.md`: added a dated status-update callout
+  clarifying that this file's own 8-issue Safety Core scope is fully
+  closed, while the broader `v0.3.1` milestone (which later absorbed #43)
+  is not.
+- `README.md`: added a "Integration test gate (issue #18)" subsection
+  under `## Testing` documenting the exact required Compose services, the
+  exact gate command (`uv run pytest -q -m integration
+  tests/integration_tests.py`), and the expected `5 passed` result with no
+  xfail/skip/optional MCP path. The existing "OIDC/JWT Authentication"
+  section (including the "Admin Portal front-channel OIDC (ISSUE 021)"
+  paragraph) and `services/admin-portal/README.md`'s "Authentication
+  (Front-Channel OIDC, ISSUE 021)" section were reviewed and found already
+  accurate: dependency-free Authorization Code + PKCE, any OIDC-compliant
+  provider (Auth0/Keycloak/Okta), access token attached as `Authorization:
+  Bearer` to Admin API calls, and no hardcoded tenant/client/audience/
+  secret (all via `NEXT_PUBLIC_OIDC_*` env vars) — no changes were needed
+  there.
+- `audit/evidence/43_deployability_verification.md` and
+  `audit/evidence/39_jetstream_durable_audit.md`: reviewed, already
+  accurate (#43 correctly described as blocked on live cluster checks;
+  #39 correctly scoped to JetStream durable audit only). No changes made.
+- `docs/roadmap/releases/v0.3.0.md`: **not created.** No `docs/roadmap/
+  releases/` directory, `CHANGELOG.md`, or other release-notes file or
+  convention exists anywhere in the tracked repository (`docs/roadmap/`
+  contains only `index.md`, `engineering_task.md`, and a flat `issues/`
+  directory). Creating a new `releases/` subdirectory would not match the
+  existing docs structure, so per this task's own conditional instruction
+  ("only if this path matches existing docs structure"), the release
+  evidence lives in this file instead, following the established
+  `audit/evidence/<issue>_<topic>.md` naming convention used by
+  `18_integration_ci_gate.md`, `39_jetstream_durable_audit.md`, and
+  `43_deployability_verification.md`.
+
+No runtime behavior was changed by this pass. No dependency was upgraded,
+downgraded, or remediated. No feature was added.
+
+## Final validation commands and exact results
+
+```text
+$ uv run mypy .
+Success: no issues found in 161 source files
+
+$ uv run ruff check core/src services/api-gateway/src services/api-gateway/tests services/admin_api mcp/src mcp/tests
+All checks passed!
+
+$ uv run ruff format --check core/src services/api-gateway/src services/api-gateway/tests services/admin_api mcp/src mcp/tests
+87 files already formatted
+
+$ uv run pytest -q services/api-gateway/tests services/admin_api/tests mcp/tests
+462 passed
+
+$ uv run pytest -q --cov-report=xml:coverage.xml
+481 passed
+
+$ uv run python scripts/license_headers.py --check
+License headers verified; would normalize 0 file(s).
+
+$ bash scripts/check-openapi-version.sh
+(exit 0)
+
+$ docker compose -f docker-compose.yml config
+(exit 0)
+
+$ docker compose -f docker-compose.dev.yml config
+(exit 0)
+
+$ uv run python scripts/ci/verify_build_baseline.py
+Reproducible-build baseline OK: 12 Dockerfile(s), 3 compose file(s) checked.
+```
+
+## Admin Portal validation (Node.js 22 only)
+
+Node baseline confirmed via `nvm use 22` (`~/.nvm`), never Node 26 (also
+installed locally but not used):
+
+```text
+$ node --version
+v22.23.1
+$ npm --version
+10.9.8
+
+$ npm ci
+added 520 packages, and audited 521 packages in 12s
+13 vulnerabilities (6 moderate, 7 high)   # pre-existing; npm audit fix NOT run (out of scope)
+
+$ npm run openapi:gen
+🚀 .../openapi/astradesk-admin.v1.yaml → .../services/admin-portal/src/api/types.gen.ts [135.8ms]
+✅ OpenAPI types generated successfully.
+# services/admin-portal/src/api/types.gen.ts: SHA-256 identical before and after
+# regeneration (a10d3297...) — no diff, no change to report/stage.
+
+$ npm run openapi:check
+OpenAPI artifacts up-to-date.
+
+$ npm run typecheck
+(tsc --noEmit; exit 0, no output)
+
+$ npm run lint
+(eslint . --max-warnings=0; exit 0, no output)
+
+$ npm test
+Test Files  7 passed (7)
+     Tests  31 passed (31)
+
+$ NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 npm run build
+✓ Compiled successfully in 3.1s
+✓ Generating static pages (3/3)
+(26 routes built, all dynamic/server-rendered on demand)
+```
+
+`npm audit fix` was **not** run, per this task's explicit out-of-scope
+constraint; the 13 pre-existing advisories (from `npm ci`) are unchanged
+and unremediated by this pass.
+
+## Integration gate validation
+
+```text
+$ docker compose -f docker-compose.dev.yml up -d --wait --wait-timeout 180 \
+    postgres redis nats mcp-support mcp-ops mcp-finance mcp-supply
+(exit 0; all 7 containers healthy)
+
+$ DATABASE_URL=postgresql://astradesk:astradesk@localhost:5432/astradesk \
+  REDIS_URL=redis://localhost:6379/0 \
+  NATS_URL=nats://localhost:4222 \
+  AUTH_MODE=local-dev \
+  ASTRADESK_DEV_JWT_SECRET=integration-test-secret \
+  ENVIRONMENT=ci \
+  uv run pytest -q -m integration tests/integration_tests.py
+5 passed in ~29s
+
+$ docker compose -f docker-compose.dev.yml down -v
+(exit 0; containers, volumes, and network removed)
+
+$ docker ps -a
+(empty — no leftover containers)
+```
+
+No xfail, no skip, no optional/best-effort MCP server path — all 4
+domain-pack MCP servers were required and healthy.
+
+## Product/version status
+
+- `pyproject.toml`'s `[project].version` remains `0.3.0` — unchanged
+  (this pass performed no version bump; none was in scope or requested).
+- `openapi/astradesk-admin.v1.yaml`'s Admin API contract version remains
+  `1.2.0` — unchanged.
+
+## Node.js baseline status
+
+- `.github/workflows/ci.yml`'s `NODE_VERSION: "22"` is unchanged.
+- `README.md`'s `Node.js-22-brightgreen` badge is unchanged.
+- `services/admin-portal/README.md`'s "Node.js 22 LTS" prerequisite is
+  unchanged.
+- Node 26 was available locally (via `nvm`) but was never selected or
+  used for any command in this pass; all Admin Portal commands above ran
+  under Node 22.23.1 / npm 10.9.8.
+
+## Generated/cache/local artifacts (not committed)
+
+- `coverage.xml` (Python, root) — regenerated by verification runs, not
+  staged.
+- `services/admin-portal/.next/`, `node_modules/`, `coverage/` — created
+  locally by `npm ci`/`npm test`/`npm run build`, gitignored, not staged
+  (confirmed via `git status` showing no admin-portal changes after these
+  commands).
+- `/tmp/astradesk-compose-full.out`, `/tmp/astradesk-compose-dev.out` —
+  scratch redirect targets for the compose `config` checks, outside the
+  repository.
+
+## Explicit statement
+
+**Issue #43 was not touched, not closed, and no live AWS/Kubernetes check
+was performed.** `v0.3.1` is not marked complete. No Node.js migration was
+performed (22 remains the baseline; 26 was never invoked). `npm audit fix`
+was not run. No dependency remediation, feature addition, or runtime
+behavior change was made; the only file touched outside `docs/`,
+`README.md`, and `audit/evidence/` is none — this pass is documentation
+and evidence only.

--- a/docs/roadmap/engineering_task.md
+++ b/docs/roadmap/engineering_task.md
@@ -21,6 +21,17 @@ See the LICENSE file in the project root for the full license text.
 **Source of truth**: `audit-report.md` Rev 2, `roadmap.md` §2 Phase 1–2
 **Design stance**: contract-first, evidence-driven, fail-closed. Every task states invariants, interfaces, failure modes, and the artifact that proves it done.
 
+> **Status update (2026-07-06, issue #65)**: the 8-issue Safety Core scope
+> defined in this file (§5 Issue index: rescoped #9/#16/#19/#28,
+> NEW-1/NEW-2/NEW-4/NEW-SEC — closed as #37/#38/#39/#28/#40/#41/#42 and the
+> admin-proxy-auth PR) is **fully closed**. The broader `v0.3.1` milestone
+> is **not** complete: issue #43 (Helm/Terraform/Istio live deployability,
+> consolidated from the roadmap's separate Phase 2 deployability item and
+> added to this milestone after this file was written) remains open,
+> blocked on live AWS/Kubernetes checks — see
+> `audit/evidence/43_deployability_verification.md`. Do not read this
+> update as closing `v0.3.1`.
+
 ---
 
 ## 0. Engineering philosophy — best patterns, immunized against their childhood diseases

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -20,6 +20,18 @@ See the LICENSE file in the project root for the full license text.
 **Inputs**: `audit-report.md` Rev 2 (tree `2d59d75`), live tracker (28 issues / 7 milestones)
 **Source of truth**: every roadmap item traces to an audit finding or a tracked issue. No aspirational item is included without evidence. Effort is expressed as relative horizons and **evidence-backed gates**, not invented dates.
 
+> **Status update (2026-07-06, issue #65)**: milestone `v0.3.0 — AWS-Ready
+> Deployment` is now **fully closed** (#17, #18, #19, #20, #21) — see
+> `audit/evidence/v0.3.0_final_validation.md`. Milestone
+> `v0.3.1 — Commercial Workhorse Hardening` has closed 7 of its 8 issues
+> (#28, #37, #38, #39, #40, #41, #42); **#43 remains open**, blocked on
+> live AWS/Kubernetes checks that require a provisioned cluster/account
+> (see `audit/evidence/43_deployability_verification.md`) — `v0.3.1` and
+> the Track A "Commercial Workhorse v1" gate below are **not** complete.
+> The rest of this document is preserved as written at the 2026-06-28
+> planning snapshot; items below referring to #18/#21/#39 as open work
+> reflect that snapshot, not current status.
+
 ---
 
 ## 0. How to read this roadmap
@@ -81,7 +93,7 @@ This is the heart of the workhorse. All items are audit Criticals/Highs.
 2. **Reproducible images.** Rebuild all Python images from `pyproject.toml`/`uv.lock` on **Python 3.13**, non-root `USER`, drop the missing-`requirements.txt` copies. *(§3.1, §3.3, §7; NEW-2)*
 3. **One baseline, pinned.** Align dev/prod DB+cache (pgvector image for dev), pin patches/digests; verify the pgvector migration on an empty volume. *(§6)*
 4. **Deployment verified, partially — all offline checks done and the canonical Istio architecture decision applied; only cluster-gated checks remain.** `helm lint`/`helm template`, `istioctl validate`, and `terraform validate` (root + all 5 modules: `vpc`, `eks`, `rds-postgres`, `rds-mysql`, `s3`) now all pass (four real bugs found and fixed: two Helm template/naming bugs, one Istio schema bug, one Istio routing-order bug; plus the `eks` module's incompatibility with the current `hashicorp/aws` provider line resolved via a `required_providers` version constraint — see `audit/evidence/43_deployability_verification.md`). The maintainer chose **Generation A** (`astradesk-prod`, routes all four services, matches both tracked pipelines) as canonical over Generation B (`astradesk`, API-only routing, not referenced by any executable pipeline step); Generation B is relocated to `deploy/istio/generation-b-reference/` (kept for reference, not applied by `kubectl apply -f deploy/istio/`), and stale top-level `infra/` Terraform paths in `Jenkinsfile`/`.gitlab-ci.yml`/referencing docs are fixed to `deploy/infra/`. Porting Generation B's `AuthorizationPolicy`/certificate strategy forward is explicitly deferred to a separate future issue, not part of #43. `helm install`, `terraform plan`/`apply`, `istioctl analyze` against a live mesh, and the negative-connectivity test still require a provisioned cluster/AWS account and were not performed. *(issue #43, consolidating #5/#12/#15/#17 → in progress, not closed)*
-5. **Executable integration gate.** Repair `tests/integration_tests.py` collection, mark every test, run Compose-backed `pytest -m integration` as a protected gate. *(§3.2, issue #18 → RESCOPE)*
+5. **Executable integration gate — done.** `tests/integration_tests.py` collects and runs correctly; every test carries the `integration` marker; `.github/workflows/ci.yml`'s `integration-tests` job runs the Compose-backed `uv run pytest -q -m integration tests/integration_tests.py` as a required, always-run gate (Postgres/Redis/NATS plus all 4 domain-pack MCP servers, no `|| true`) and reports **`5 passed`**, zero xfail/skip. *(§3.2, issue #18 → RESOLVED, see `audit/evidence/18_integration_ci_gate.md`)*
 
 ### Phase 3 — Trustworthy Docs & Honest Artifacts ("developer can rely on it") → `v0.4.0`
 
@@ -96,7 +108,7 @@ This is the heart of the workhorse. All items are audit Criticals/Highs.
 
 AstraDesk is client-deployable when **all** of the following produce reproducible evidence:
 
-- [ ] `main` and `develop` CI green; integration gate executable and passing.
+- [ ] `main` and `develop` CI green; integration gate executable and passing. **Integration gate: done** — `uv run pytest -q -m integration tests/integration_tests.py` runs in CI against real Compose services and reports `5 passed`, zero xfail (issue #18, `audit/evidence/18_integration_ci_gate.md`). Box stays unchecked pending a confirmed green `main`/`develop` CI run beyond this local reproduction.
 - [ ] No secret in any tracked file; secret-scan gate active.
 - [ ] OIDC enforced at active ingress; HS256 fallback disabled outside local mode.
 - [ ] Every `write`/`execute` tool denies without role on **both** planning paths (negative tests prove it).
@@ -149,6 +161,8 @@ To keep the partner conversation credible:
 3. **RESCOPE in place** (comment + relabel, do not reopen): #9, #16, #18, #19, #28 carry residual workhorse debt into `v0.3.0`/`v0.3.1`; #14, #5, #12, #15, #17 carry deployability/verification debt.
 4. **KEEP**: #21 (OIDC portal) and #23 (E2E) move into the Track A scope they belong to; #24/#25/#26/#27 stay in Track B milestones.
 5. All execution (issue/milestone creation, closing, labelling) is performed by a human; this roadmap is the plan, not the mutation.
+
+**Execution status (2026-07-06)**: items 1–4 above have been carried out. Milestone `v0.3.1` exists; issues 9, 16, 28, and 19 were rescoped and closed as issues 37, 38, 28, and 39 respectively; issues 18 and 21 (item 4, "KEEP") are closed under `v0.3.0`. Of item 3's deployability debt (issues 14, 5, 12, 15, 17), only issue 43 remains open. Issue 23 (Portal E2E) remains open under `v0.4.0`, out of scope for this update.
 
 ---
 


### PR DESCRIPTION
Implements:
- #65 v0.3.0 release documentation sync and final validation.
- Synchronizes repository documentation with the completed v0.3.0 state.
- Documents #18 integration gate completion and #21 Admin Portal OIDC completion.
- Keeps #43 explicitly open and blocked on live AWS/Kubernetes validation.
- Adds final validation evidence for the v0.3.0 release path.
- Confirms product version remains 0.3.0 and Admin API contract remains 1.2.0.
- Confirms Node.js 22 baseline was used for Admin Portal validation.

Closes:
- Closes #65

Must not close:
- #43 remains open and blocked on live AWS/Kubernetes checks.

Out of scope:
- #43 live deployment verification.
- v0.3.1 release.
- Runtime behavior changes.
- Feature work.
- Node 26 migration.
- npm audit fix.
- Dependency remediation.

Milestone:
- v0.3.0 AWS-Ready Deployment

Validation:
- `uv run mypy .` -> Success: no issues found in 161 source files
- `uv run ruff check core/src services/api-gateway/src services/api-gateway/tests services/admin_api mcp/src mcp/tests`
- `uv run ruff format --check core/src services/api-gateway/src services/api-gateway/tests services/admin_api mcp/src mcp/tests`
- `uv run pytest -q services/api-gateway/tests services/admin_api/tests mcp/tests`
- `uv run pytest -q --cov-report=xml:coverage.xml`
- `uv run python scripts/license_headers.py --check`
- `bash scripts/check-openapi-version.sh`
- `docker compose -f docker-compose.yml config`
- `docker compose -f docker-compose.dev.yml config`
- `uv run python scripts/ci/verify_build_baseline.py`
- `cd services/admin-portal && npm ci && npm run openapi:gen && npm run openapi:check && npm run typecheck && npm run lint && npm test && NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 npm run build`
- `docker compose -f docker-compose.dev.yml up -d --wait --wait-timeout 180 postgres redis nats mcp-support mcp-ops mcp-finance mcp-supply`
- `DATABASE_URL=... REDIS_URL=... NATS_URL=... AUTH_MODE=local-dev ASTRADESK_DEV_JWT_SECRET=... ENVIRONMENT=ci uv run pytest -q -m integration tests/integration_tests.py` -> 5 passed
- `docker compose -f docker-compose.dev.yml down -v`

Evidence:
- `audit/evidence/v0.3.0_final_validation.md`

Notes:
- `coverage.xml` is generated during validation and intentionally not committed.
- Admin Portal OpenAPI generation was byte-identical.
- No Node 26 validation was used.
- No npm audit fix was run.
